### PR TITLE
Template Intent module should accept language parameter in any case

### DIFF
--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -17,7 +17,7 @@ description:
 - Manage operation related to image importation, distribution, activation and tagging image as golden
 - API to fetch a software image from remote file system using URL for HTTP/FTP and upload it to DNA Center.
   Supported image files extensions are bin, img, tar, smu, pie, aes, iso, ova, tar_gz and qcow2.
-- API to fethc a software image from local file system and upload it to DNA Center
+- API to fetch a software image from local file system and upload it to DNA Center
   Supported image files extensions are bin, img, tar, smu, pie, aes, iso, ova, tar_gz and qcow2.
 - API to tag/untag image as golen for a given family of devices
 - API to distribute a software image on a given device. Software image must be imported successfully into
@@ -550,8 +550,6 @@ class DnacSwims:
                 op_modifies=True,
                 params=url_import_params,
             )
-            if self.log:
-                log(str(response))
         else:
             image_name = self.want.get("local_import_details").get("filePath")
             local_import_params = dict(
@@ -568,8 +566,9 @@ class DnacSwims:
                 params=local_import_params,
                 file_paths=[('file_path', 'file')],
             )
-            if self.log:
-                log(str(response))
+
+        if self.log:
+            log(str(response))
 
         task_details = {}
         task_id = response.get("response").get("taskId")

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -23,7 +23,7 @@ description:
 - API to distribute a software image on a given device. Software image must be imported successfully into
   DNA Center before it can be distributed.
 - API to activate a software image on a given device. Software image must be present in the device flash.
-version_added: '6.4.0'
+version_added: '6.6.0'
 extends_documentation_fragment:
   - cisco.dnac.intent_params
 author: Madhan Sankaranarayanan (@madhansansel)

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -699,7 +699,7 @@ class DnacTemplate:
             deviceTypes=dict(type="list", elements='dict'),
             failurePolicy=dict(type="str"),
             id=dict(type="str"),
-            language=dict(required=False, choices=['velocity', 'jinja']),
+            language=dict(type="str"),
             lastUpdateTime=dict(type="int"),
             latestVersionTime=dict(type="int"),
             name=dict(type="str"),
@@ -743,6 +743,11 @@ class DnacTemplate:
                     if not temp.get("language") or not temp.get("deviceTypes") \
                             or not temp.get("softwareType"):
                         msg = "missing required arguments: language or deviceTypes or softwareType"
+                        self.module.fail_json(msg=msg)
+                    if not (temp.get("language").lower() == "velocity" or
+                            temp.get("language").lower() == "jinja"):
+                        msg = "Invalid parameters in playbook: {0} : Invalid choice provided".format(
+                            "".join(temp.get("language")))
                         self.module.fail_json(msg=msg)
 
     def get_dnac_params(self, params):

--- a/tests/unit/modules/dnac/fixtures/swim_intent.json
+++ b/tests/unit/modules/dnac/fixtures/swim_intent.json
@@ -34,6 +34,24 @@
 			}
 		}
 	}],
+	"playbook_config_local_image_import": [{
+		"importImageDetails": {
+			"type": "local",
+			"localImageDetails": {
+				"filePath":"/tmp/cat9k_iosxe.BLD_V179_THROTTLE_LATEST_20220429_033422.SSA.bin",
+				"isThirdParty": 0
+			}
+		}
+	}],
+	"playbook_config_incorrect_image_import_parameter": [{
+		"importImageDetails": {
+			"type": "locla",
+			"localImageDetails": {
+				"filePath":"/tmp/cat9k_iosxe.BLD_V179_THROTTLE_LATEST_20220429_033422.SSA.bin",
+				"isThirdParty": 0
+			}
+		}
+	}],
 	"playbook_config_untag_golden_image":[{
 		"taggingDetails": {
 			"imageName": "cat9k_iosxe.BLD_V179_THROTTLE_LATEST_20220429_033422.SSA.bin",

--- a/tests/unit/modules/dnac/test_swim_intent.py
+++ b/tests/unit/modules/dnac/test_swim_intent.py
@@ -73,6 +73,11 @@ class TestDnacSwimIntent(TestDnacModule):
                 self.test_data.get("task_info_response"),
                 self.test_data.get("image_already_exists_response"),
             ]
+        elif "swim_image_local_import" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("task_info_response"),
+                self.test_data.get("image_already_exists_response"),
+            ]
         elif "untag_image" in self._testMethodName:
             self.run_dnac_exec.side_effect = [
                 self.test_data.get("image_id_fetched_successfully_response"),
@@ -140,6 +145,22 @@ class TestDnacSwimIntent(TestDnacModule):
                 dnac_password="dummy",
                 dnac_log=True,
                 config=self.test_data.get("playbook_config_image_import")
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+        self.assertEqual(
+            result.get('msg'),
+            "Image already exists."
+        )
+
+    def test_swim_image_local_import(self):
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                config=self.test_data.get("playbook_config_local_image_import")
             )
         )
         result = self.execute_module(changed=False, failed=False)
@@ -306,4 +327,20 @@ class TestDnacSwimIntent(TestDnacModule):
         self.assertEqual(
             result.get('msg'),
             "Device not found"
+        )
+
+    def test_swim_incorrect_image_import_parameter(self):
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                config=self.test_data.get("playbook_config_incorrect_image_import_parameter")
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        self.assertEqual(
+            result.get('msg'),
+            "Incorrect import type. Supported Values: local or url"
         )


### PR DESCRIPTION
Problem Description:
a) template_intent module does not allow documented values for language parameter (Issue #91). cisco.dnac.template_intent requires a parameter called "language". According to the module docs and the DNAC API docs the allowed values are "JINJA" or "VELOCITY". The module does not accept these and will only accept "jinja" or "velocity".

b) Swim intent module to copy image from local.

Fix: 
a) Accept any case(lower and upper) in the modules code.
b) Added support for copying image from local to DNAC.

UT:
Fixes are verified.
