### PR TITLE
6.9.0:

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following table shows the supported versions.
 | 2.2.2.3                  | 3.3.1                        | 2.3.3                         |
 | 2.2.3.3                  | 6.4.0                        | 2.4.11                        |
 | 2.3.3.0                  | 6.6.4                        | 2.5.5                         |
-| 2.3.5.3                  | 6.7.5                        | 2.6.0                         |
+| 2.3.5.3                  | 6.9.0                        | 2.6.0                         |
 
 If your Ansible collection is older please consider updating it first.
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -742,4 +742,10 @@ releases:
         release_summary: Changing galaxy.
         bugfixes:
           - Adding support to ansible.utils >=3.0
-          - pnp_device_claim_to_site.py change configInfo from `list` to `dict` #135 
+          - pnp_device_claim_to_site.py change configInfo from `list` to `dict` #135
+    6.9.0:
+      release_date: "2023-12-05"
+      changes:
+        release_summary: Changing galaxy.
+        bugfixes:
+          - Adding support to ansible.utils ">=2.0.0, <4.00".

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: dnac
-version: 6.8.2
+version: 6.9.0
 readme: README.md
 authors:
   - Rafael Campos <rcampos@altus.cr>
@@ -21,7 +21,7 @@ tags:
   - networking
   - sdn
 dependencies:
-  ansible.utils: ">=3.0"
+  ansible.utils: ">=2.0.0,<4.0"
 repository: https://github.com/cisco-en-programmability/dnacenter-ansible
 documentation: https://cisco-en-programmability.github.io/dnacenter-ansible/
 homepage: https://github.com/cisco-en-programmability/dnacenter-ansible


### PR DESCRIPTION
      release_date: "2023-12-05"
      changes:
        release_summary: Changing galaxy.
        bugfixes:
          - Adding support to ansible.utils ">=2.0.0, <4.00".