### PR TITLE
Stackswith getting changed to normal switch

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: dnac
-version: 6.11.1
+version: 6.12.0
 readme: README.md
 authors:
   - Rafael Campos <rcampos@altus.cr>

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -359,7 +359,7 @@ notes:
 
 EXAMPLES = r"""
 - name: Execute discovery devices with both global credentials and discovery specific credentials
-  cisco.dnac.discovery_intent:
+  cisco.dnac.discovery_workflow_manager:
     dnac_host: "{{dnac_host}}"
     dnac_username: "{{dnac_username}}"
     dnac_password: "{{dnac_password}}"


### PR DESCRIPTION
Problem Description: 
Whenever the user tries to claim a Stack Switch using the playbook and tries to edit the device info like hostname/serial_number/pid, then it automatically gets converted to a normal switch.

Root Cause: 
This conversion happens due to a bug in the update_device API under PnP, which automatically makes stack as False if not passed in the payload.

Code Changes: Have added a check for the stack. If the device is a stack, it automatically takes stack as True for passing the payload to the API, bypassing the bug.
