### PR TITLE
Ansible partner changes for end of May

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,21 +6,21 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
     branches:
       - main
-
+  workflow_dispatch:
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: configure git
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@bots.github.com"
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.11"
       - name: Install dependencies
         run: make doc-setup
       - name: Build docs

--- a/.github/workflows/sanity_tests.yml
+++ b/.github/workflows/sanity_tests.yml
@@ -10,6 +10,13 @@ env:
   NAMESPACE: cisco
   COLLECTION_NAME: dnac 
 jobs:
+  # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+  # 2.14 supports Python 3.9-3.11
+  # 2.15 supports Python 3.9-3.11
+  # 2.16 supports Python 3.10-3.12
+  # https://docs.ansible.com/ansible/devel/roadmap/ROADMAP_2_17.html
+  # milestone is 2.17 until after 2.17 branches from devel
+  # devel is 2.17 until 2024-04-01
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }})
     strategy:
@@ -17,6 +24,7 @@ jobs:
         ansible:
           - stable-2.15
           - stable-2.16
+          - stable-2.17
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code

--- a/.github/workflows/sanity_tests_devel.yml
+++ b/.github/workflows/sanity_tests_devel.yml
@@ -1,10 +1,5 @@
-name: CI
+name: CI Devel
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-  schedule:
-    - cron: '0 6 * * *'
   workflow_dispatch:
 env:
   NAMESPACE: cisco
@@ -15,8 +10,7 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.15
-          - stable-2.16
+          - devel
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The following table shows the supported versions.
 
 | Cisco DNA Center version | Ansible "cisco.dnac" version | Python "dnacentersdk" version |
 |--------------------------|------------------------------|-------------------------------|
-| 2.1.1                    | 3.0.0                        | 2.2.5                         |
-| 2.2.2.3                  | 3.3.1                        | 2.3.3                         |
-| 2.2.3.3                  | 6.4.0                        | 2.4.11                        |
-| 2.3.3.0                  | 6.6.4                        | 2.5.5                         |
-| 2.3.5.3                  | 6.13.0                       | 2.6.0                         |
+| 2.1.1                    | 3.0.0                        |  2.2.5                        |
+| 2.2.2.3                  | 3.3.1                        |  2.3.3                        |
+| 2.2.3.3                  | 6.4.0                        |  2.4.11                       |
+| 2.3.3.0                  | 6.6.4                        |  2.5.5                        |
+| 2.3.5.3                  | ^6.13.0                      | ^2.6.0                        |
 
 If your Ansible collection is older please consider updating it first.
 
@@ -44,9 +44,9 @@ ansible-galaxy collection install cisco.dnac:3.3.1
 ```
 
 ## Requirements
-- Ansible >= 2.9
-- [Python DNA Center SDK](https://github.com/cisco-en-programmability/dnacentersdk) v2.4.7 or newer
-- Python >= 3.6, as the DNA Center SDK doesn't support Python version 2.x
+- Ansible >= 2.15
+- [Python DNA Center SDK](https://github.com/cisco-en-programmability/dnacentersdk) v2.6.0 or newer
+- Python >= 3.9, as the DNA Center SDK doesn't support Python version 2.x
 
 ## Install
 Ansible must be installed ([Install guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: '>=2.15.0'

--- a/plugins/modules/accesspoint_configuration_details_by_task_id_info.py
+++ b/plugins/modules/accesspoint_configuration_details_by_task_id_info.py
@@ -24,8 +24,8 @@ options:
     - Task_id path parameter. Task id information of ap config.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless GetAccessPointConfigurationTaskResult
   description: Complete reference of the GetAccessPointConfigurationTaskResult API.

--- a/plugins/modules/app_policy_default_info.py
+++ b/plugins/modules/app_policy_default_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplicationPolicyDefault
   description: Complete reference of the GetApplicationPolicyDefault API.

--- a/plugins/modules/app_policy_info.py
+++ b/plugins/modules/app_policy_info.py
@@ -24,8 +24,8 @@ options:
     - PolicyScope query parameter. Policy scope name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplicationPolicy
   description: Complete reference of the GetApplicationPolicy API.

--- a/plugins/modules/app_policy_intent_create.py
+++ b/plugins/modules/app_policy_intent_create.py
@@ -226,8 +226,8 @@ options:
         type: dict
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy ApplicationPolicyIntent
   description: Complete reference of the ApplicationPolicyIntent API.

--- a/plugins/modules/app_policy_queuing_profile.py
+++ b/plugins/modules/app_policy_queuing_profile.py
@@ -89,8 +89,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy CreateApplicationPolicyQueuingProfile
   description: Complete reference of the CreateApplicationPolicyQueuingProfile API.

--- a/plugins/modules/app_policy_queuing_profile_count_info.py
+++ b/plugins/modules/app_policy_queuing_profile_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplicationPolicyQueuingProfileCount
   description: Complete reference of the GetApplicationPolicyQueuingProfileCount API.

--- a/plugins/modules/app_policy_queuing_profile_info.py
+++ b/plugins/modules/app_policy_queuing_profile_info.py
@@ -24,8 +24,8 @@ options:
     - Name query parameter. Queuing profile name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplicationPolicyQueuingProfile
   description: Complete reference of the GetApplicationPolicyQueuingProfile API.

--- a/plugins/modules/application_sets.py
+++ b/plugins/modules/application_sets.py
@@ -29,8 +29,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy CreateApplicationSet
   description: Complete reference of the CreateApplicationSet API.

--- a/plugins/modules/application_sets_count_info.py
+++ b/plugins/modules/application_sets_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplicationSetsCount
   description: Complete reference of the GetApplicationSetsCount API.

--- a/plugins/modules/application_sets_info.py
+++ b/plugins/modules/application_sets_info.py
@@ -32,8 +32,8 @@ options:
     - Name query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplicationSets
   description: Complete reference of the GetApplicationSets API.

--- a/plugins/modules/applications.py
+++ b/plugins/modules/applications.py
@@ -133,8 +133,8 @@ options:
         type: list
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy CreateApplication
   description: Complete reference of the CreateApplication API.

--- a/plugins/modules/applications_count_info.py
+++ b/plugins/modules/applications_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplicationsCount
   description: Complete reference of the GetApplicationsCount API.

--- a/plugins/modules/applications_health_info.py
+++ b/plugins/modules/applications_health_info.py
@@ -64,8 +64,8 @@ options:
     - ApplicationName query parameter. The name of the application to get information on.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Applications Applications
   description: Complete reference of the Applications API.

--- a/plugins/modules/applications_info.py
+++ b/plugins/modules/applications_info.py
@@ -32,8 +32,8 @@ options:
     - Name query parameter. Application's name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetApplications
   description: Complete reference of the GetApplications API.

--- a/plugins/modules/assign_device_to_site.py
+++ b/plugins/modules/assign_device_to_site.py
@@ -31,8 +31,8 @@ options:
     description: SiteId path parameter. Site id to which site the device to assign.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for  AssignDevicesToSite
   description: Complete reference of the AssignDevicesToSite API.

--- a/plugins/modules/associate_site_to_network_profile.py
+++ b/plugins/modules/associate_site_to_network_profile.py
@@ -23,8 +23,8 @@ options:
     description: SiteId path parameter. Site Id to be associated.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Site Design Associate
   description: Complete reference of the Associate API.

--- a/plugins/modules/authentication_import_certificate.py
+++ b/plugins/modules/authentication_import_certificate.py
@@ -30,8 +30,8 @@ options:
     description: PkPassword query parameter. Private Key Passsword.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Authentication Management ImportCertificate
   description: Complete reference of the ImportCertificate API.

--- a/plugins/modules/authentication_import_certificate_p12.py
+++ b/plugins/modules/authentication_import_certificate_p12.py
@@ -30,8 +30,8 @@ options:
     description: PkPassword query parameter. Private Key Passsword.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Authentication Management ImportCertificateP12
   description: Complete reference of the ImportCertificateP12 API.

--- a/plugins/modules/authentication_policy_servers_info.py
+++ b/plugins/modules/authentication_policy_servers_info.py
@@ -32,8 +32,8 @@ options:
     - Role query parameter. Authentication and Policy Server Role (Example primary, secondary).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for System Settings GetAuthenticationAndPolicyServers
   description: Complete reference of the GetAuthenticationAndPolicyServers API.

--- a/plugins/modules/buildings_planned_access_points_info.py
+++ b/plugins/modules/buildings_planned_access_points_info.py
@@ -36,8 +36,8 @@ options:
     - Radios query parameter. Inlcude planned radio details.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetPlannedAccessPointsForBuilding
   description: Complete reference of the GetPlannedAccessPointsForBuilding API.

--- a/plugins/modules/business_sda_hostonboarding_ssid_ippool.py
+++ b/plugins/modules/business_sda_hostonboarding_ssid_ippool.py
@@ -34,8 +34,8 @@ options:
     description: VLAN Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Fabric Wireless AddSSIDToIPPoolMapping
   description: Complete reference of the AddSSIDToIPPoolMapping API.

--- a/plugins/modules/business_sda_hostonboarding_ssid_ippool_info.py
+++ b/plugins/modules/business_sda_hostonboarding_ssid_ippool_info.py
@@ -28,8 +28,8 @@ options:
     - SiteNameHierarchy query parameter. Site Name Heirarchy.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Fabric Wireless GetSSIDToIPPoolMapping
   description: Complete reference of the GetSSIDToIPPoolMapping API.

--- a/plugins/modules/business_sda_virtual_network_summary_info.py
+++ b/plugins/modules/business_sda_virtual_network_summary_info.py
@@ -24,8 +24,8 @@ options:
     - SiteNameHierarchy query parameter. Complete fabric siteNameHierarchy Path.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for  GetVirtualNetworkSummary
   description: Complete reference of the GetVirtualNetworkSummary API.

--- a/plugins/modules/business_sda_wireless_controller_create.py
+++ b/plugins/modules/business_sda_wireless_controller_create.py
@@ -23,8 +23,8 @@ options:
     description: Site Name Hierarchy.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Fabric Wireless AddWLCToFabricDomain
   description: Complete reference of the AddWLCToFabricDomain API.

--- a/plugins/modules/business_sda_wireless_controller_delete.py
+++ b/plugins/modules/business_sda_wireless_controller_delete.py
@@ -23,8 +23,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Fabric Wireless RemoveWLCFromFabricDomain
   description: Complete reference of the RemoveWLCFromFabricDomain API.

--- a/plugins/modules/cli_credential.py
+++ b/plugins/modules/cli_credential.py
@@ -45,8 +45,8 @@ options:
     description: Cli Credential's username.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateCLICredentials
   description: Complete reference of the CreateCLICredentials API.

--- a/plugins/modules/client_detail_info.py
+++ b/plugins/modules/client_detail_info.py
@@ -28,8 +28,8 @@ options:
     - MacAddress query parameter. MAC Address of the client.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Clients GetClientDetail
   description: Complete reference of the GetClientDetail API.

--- a/plugins/modules/client_enrichment_details_info.py
+++ b/plugins/modules/client_enrichment_details_info.py
@@ -22,8 +22,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Clients GetClientEnrichmentDetails
   description: Complete reference of the GetClientEnrichmentDetails API.

--- a/plugins/modules/client_health_info.py
+++ b/plugins/modules/client_health_info.py
@@ -24,8 +24,8 @@ options:
     - Timestamp query parameter. Epoch time(in milliseconds) when the Client health data is required.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Clients GetOverallClientHealth
   description: Complete reference of the GetOverallClientHealth API.

--- a/plugins/modules/client_proximity_info.py
+++ b/plugins/modules/client_proximity_info.py
@@ -40,8 +40,8 @@ options:
       with a minimum 5 minutes.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Clients ClientProximity
   description: Complete reference of the ClientProximity API.

--- a/plugins/modules/command_runner_run_command.py
+++ b/plugins/modules/command_runner_run_command.py
@@ -34,8 +34,8 @@ options:
     description: Command Runner Run Command's timeout.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Command Runner RunReadOnlyCommandsOnDevicesToGetTheirRealTimeConfiguration
   description: Complete reference of the RunReadOnlyCommandsOnDevicesToGetTheirRealTimeConfiguration API.

--- a/plugins/modules/compliance_check_run.py
+++ b/plugins/modules/compliance_check_run.py
@@ -28,8 +28,8 @@ options:
     description: TriggerFull flag.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Compliance RunCompliance
   description: Complete reference of the RunCompliance API.

--- a/plugins/modules/compliance_device_by_id_info.py
+++ b/plugins/modules/compliance_device_by_id_info.py
@@ -46,8 +46,8 @@ options:
     - Value query parameter. Extended attribute value.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Compliance ComplianceDetailsOfDevice
   description: Complete reference of the ComplianceDetailsOfDevice API.

--- a/plugins/modules/compliance_device_details_count_info.py
+++ b/plugins/modules/compliance_device_details_count_info.py
@@ -32,8 +32,8 @@ options:
       'IN_PROGRESS', 'NOT_AVAILABLE', 'NOT_APPLICABLE', 'ERROR'.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Compliance GetComplianceDetailCount
   description: Complete reference of the GetComplianceDetailCount API.

--- a/plugins/modules/compliance_device_details_info.py
+++ b/plugins/modules/compliance_device_details_info.py
@@ -44,8 +44,8 @@ options:
     - Limit query parameter. Number of records to be retrieved.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Compliance GetComplianceDetail
   description: Complete reference of the GetComplianceDetail API.

--- a/plugins/modules/compliance_device_info.py
+++ b/plugins/modules/compliance_device_info.py
@@ -40,8 +40,8 @@ options:
     - Limit query parameter. Number of records to be retrieved.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Compliance DeviceComplianceStatus
   description: Complete reference of the DeviceComplianceStatus API.

--- a/plugins/modules/compliance_device_status_count_info.py
+++ b/plugins/modules/compliance_device_status_count_info.py
@@ -26,8 +26,8 @@ options:
       'IN_PROGRESS', 'NOT_AVAILABLE', 'NOT_APPLICABLE', 'ERROR'.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Compliance GetComplianceStatusCount
   description: Complete reference of the GetComplianceStatusCount API.

--- a/plugins/modules/configuration_template.py
+++ b/plugins/modules/configuration_template.py
@@ -512,8 +512,8 @@ options:
     description: Current version of template.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates DeletesTheTemplate
   description: Complete reference of the DeletesTheTemplate API.

--- a/plugins/modules/configuration_template_clone.py
+++ b/plugins/modules/configuration_template_clone.py
@@ -28,8 +28,8 @@ options:
     description: TemplateId path parameter. UUID of the template to clone it.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates CreatesACloneOfTheGivenTemplate
   description: Complete reference of the CreatesACloneOfTheGivenTemplate API.

--- a/plugins/modules/configuration_template_create.py
+++ b/plugins/modules/configuration_template_create.py
@@ -508,8 +508,8 @@ options:
     description: Current version of template.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates CreateTemplate
   description: Complete reference of the CreateTemplate API.

--- a/plugins/modules/configuration_template_deploy.py
+++ b/plugins/modules/configuration_template_deploy.py
@@ -55,8 +55,8 @@ options:
     description: UUID of template to be provisioned.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates DeployTemplate
   description: Complete reference of the DeployTemplate API.

--- a/plugins/modules/configuration_template_deploy_status_info.py
+++ b/plugins/modules/configuration_template_deploy_status_info.py
@@ -24,8 +24,8 @@ options:
     - DeploymentId path parameter. UUID of deployment to retrieve template deployment status.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates StatusOfTemplateDeployment
   description: Complete reference of the StatusOfTemplateDeployment API.

--- a/plugins/modules/configuration_template_deploy_v2.py
+++ b/plugins/modules/configuration_template_deploy_v2.py
@@ -55,8 +55,8 @@ options:
     description: UUID of template to be provisioned.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates DeployTemplateV2
   description: Complete reference of the DeployTemplateV2 API.

--- a/plugins/modules/configuration_template_export_project.py
+++ b/plugins/modules/configuration_template_export_project.py
@@ -21,8 +21,8 @@ options:
     elements: dict
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates ExportsTheProjectsForAGivenCriteria
   description: Complete reference of the ExportsTheProjectsForAGivenCriteria API.

--- a/plugins/modules/configuration_template_export_template.py
+++ b/plugins/modules/configuration_template_export_template.py
@@ -21,8 +21,8 @@ options:
     elements: dict
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates ExportsTheTemplatesForAGivenCriteria
   description: Complete reference of the ExportsTheTemplatesForAGivenCriteria API.

--- a/plugins/modules/configuration_template_import_project.py
+++ b/plugins/modules/configuration_template_import_project.py
@@ -23,8 +23,8 @@ options:
       fails with 'Template already exists' error.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates ImportsTheProjectsProvided
   description: Complete reference of the ImportsTheProjectsProvided API.

--- a/plugins/modules/configuration_template_import_template.py
+++ b/plugins/modules/configuration_template_import_template.py
@@ -523,8 +523,8 @@ options:
       project.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates ImportsTheTemplatesProvided
   description: Complete reference of the ImportsTheTemplatesProvided API.

--- a/plugins/modules/configuration_template_info.py
+++ b/plugins/modules/configuration_template_info.py
@@ -76,8 +76,8 @@ options:
     - LatestVersion query parameter. LatestVersion flag to get the latest versioned template.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates GetsDetailsOfAGivenTemplate
   description: Complete reference of the GetsDetailsOfAGivenTemplate API.

--- a/plugins/modules/configuration_template_project.py
+++ b/plugins/modules/configuration_template_project.py
@@ -546,8 +546,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates CreateProject
   description: Complete reference of the CreateProject API.

--- a/plugins/modules/configuration_template_project_info.py
+++ b/plugins/modules/configuration_template_project_info.py
@@ -34,8 +34,8 @@ options:
     - ProjectId path parameter. ProjectId(UUID) of project to get project details.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates GetsAListOfProjects
   description: Complete reference of the GetsAListOfProjects API.

--- a/plugins/modules/configuration_template_version_create.py
+++ b/plugins/modules/configuration_template_version_create.py
@@ -23,8 +23,8 @@ options:
     description: UUID of template.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates VersionTemplate
   description: Complete reference of the VersionTemplate API.

--- a/plugins/modules/configuration_template_version_info.py
+++ b/plugins/modules/configuration_template_version_info.py
@@ -24,8 +24,8 @@ options:
     - TemplateId path parameter. TemplateId(UUID) to get list of versioned templates.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates GetsAllTheVersionsOfAGivenTemplate
   description: Complete reference of the GetsAllTheVersionsOfAGivenTemplate API.

--- a/plugins/modules/credential_to_site_by_siteid_create_v2.py
+++ b/plugins/modules/credential_to_site_by_siteid_create_v2.py
@@ -38,8 +38,8 @@ options:
     description: SNMPv3 Credential Id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings AssignDeviceCredentialToSiteV2
   description: Complete reference of the AssignDeviceCredentialToSiteV2 API.

--- a/plugins/modules/device_configurations_export.py
+++ b/plugins/modules/device_configurations_export.py
@@ -24,8 +24,8 @@ options:
     description: Password.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Archive ExportDeviceConfigurations
   description: Complete reference of the ExportDeviceConfigurations API.

--- a/plugins/modules/device_credential_create.py
+++ b/plugins/modules/device_credential_create.py
@@ -120,8 +120,8 @@ options:
         type: list
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings CreateDeviceCredentials
   description: Complete reference of the CreateDeviceCredentials API.

--- a/plugins/modules/device_credential_delete.py
+++ b/plugins/modules/device_credential_delete.py
@@ -20,8 +20,8 @@ options:
     description: Id path parameter. Global credential id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings DeleteDeviceCredential
   description: Complete reference of the DeleteDeviceCredential API.

--- a/plugins/modules/device_credential_info.py
+++ b/plugins/modules/device_credential_info.py
@@ -24,8 +24,8 @@ options:
     - SiteId query parameter. Site id to retrieve the credential details associated with the site.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings GetDeviceCredentialDetails
   description: Complete reference of the GetDeviceCredentialDetails API.

--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -892,9 +892,9 @@ class DnacCredential(DnacBase):
 
             _id = response.get("response")[0].get("id")
             self.log("Site ID for the site name {0}: {1}".format(site_name, _id), "INFO")
-        except Exception as exec:
+        except Exception as exception:
             self.log("Exception occurred while getting site_id from the site_name: {0}"
-                     .format(exec), "CRITICAL")
+                     .format(exception), "CRITICAL")
             return None
 
         return _id

--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -298,8 +298,8 @@ options:
                 description: snmp_v3 Credential Id. Use Description or Id.
                 type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateGlobalCredentialsV2
   description: Complete reference of the CreateGlobalCredentialsV2 API.

--- a/plugins/modules/device_credential_intent.py
+++ b/plugins/modules/device_credential_intent.py
@@ -892,9 +892,9 @@ class DnacCredential(DnacBase):
 
             _id = response.get("response")[0].get("id")
             self.log("Site ID for the site name {0}: {1}".format(site_name, _id), "INFO")
-        except Exception as exception:
+        except Exception as e:
             self.log("Exception occurred while getting site_id from the site_name: {0}"
-                     .format(exception), "CRITICAL")
+                     .format(e), "CRITICAL")
             return None
 
         return _id
@@ -918,9 +918,9 @@ class DnacCredential(DnacBase):
             global_credentials = global_credentials.get("response")
             self.log("All global device credentials details: {0}"
                      .format(global_credentials), "DEBUG")
-        except Exception as exec:
+        except Exception as e:
             self.log("Exception occurred while getting global device credentials: {0}"
-                     .format(exec), "CRITICAL")
+                     .format(e), "CRITICAL")
             return None
 
         return global_credentials

--- a/plugins/modules/device_credential_update.py
+++ b/plugins/modules/device_credential_update.py
@@ -132,8 +132,8 @@ options:
         type: dict
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings UpdateDeviceCredentials
   description: Complete reference of the UpdateDeviceCredentials API.

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -891,9 +891,9 @@ class DeviceCredential(DnacBase):
 
             _id = response.get("response")[0].get("id")
             self.log("Site ID for the site name {0}: {1}".format(site_name, _id), "INFO")
-        except Exception as exec:
+        except Exception as exception:
             self.log("Exception occurred while getting site_id from the site_name: {0}"
-                     .format(exec), "CRITICAL")
+                     .format(exception), "CRITICAL")
             return None
 
         return _id

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -891,9 +891,9 @@ class DeviceCredential(DnacBase):
 
             _id = response.get("response")[0].get("id")
             self.log("Site ID for the site name {0}: {1}".format(site_name, _id), "INFO")
-        except Exception as exception:
+        except Exception as e:
             self.log("Exception occurred while getting site_id from the site_name: {0}"
-                     .format(exception), "CRITICAL")
+                     .format(e), "CRITICAL")
             return None
 
         return _id
@@ -917,9 +917,9 @@ class DeviceCredential(DnacBase):
             global_credentials = global_credentials.get("response")
             self.log("All global device credentials details: {0}"
                      .format(global_credentials), "DEBUG")
-        except Exception as exec:
+        except Exception as e:
             self.log("Exception occurred while getting global device credentials: {0}"
-                     .format(exec), "CRITICAL")
+                     .format(e), "CRITICAL")
             return None
 
         return global_credentials

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -298,8 +298,8 @@ options:
                 description: snmp_v3 Credential Id. Use Description or Id.
                 type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco Catalyst Center documentation for Discovery CreateGlobalCredentialsV2
   description: Complete reference of the CreateGlobalCredentialsV2 API.

--- a/plugins/modules/device_details_info.py
+++ b/plugins/modules/device_details_info.py
@@ -32,8 +32,8 @@ options:
     - Identifier query parameter. One of keywords macAddress or uuid or nwDeviceName.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceDetail
   description: Complete reference of the GetDeviceDetail API.

--- a/plugins/modules/device_enrichment_details_info.py
+++ b/plugins/modules/device_enrichment_details_info.py
@@ -22,8 +22,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceEnrichmentDetails
   description: Complete reference of the GetDeviceEnrichmentDetails API.

--- a/plugins/modules/device_family_identifiers_details_info.py
+++ b/plugins/modules/device_family_identifiers_details_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) GetDeviceFamilyIdentifiers
   description: Complete reference of the GetDeviceFamilyIdentifiers API.

--- a/plugins/modules/device_health_info.py
+++ b/plugins/modules/device_health_info.py
@@ -50,8 +50,8 @@ options:
     - Offset query parameter. The offset of the first device in the returned data.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices Devices
   description: Complete reference of the Devices API.

--- a/plugins/modules/device_interface_by_ip_info.py
+++ b/plugins/modules/device_interface_by_ip_info.py
@@ -24,8 +24,8 @@ options:
     - IpAddress path parameter. IP address of the interface.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetInterfaceByIP
   description: Complete reference of the GetInterfaceByIP API.

--- a/plugins/modules/device_interface_count_info.py
+++ b/plugins/modules/device_interface_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceInterfaceCount
   description: Complete reference of the GetDeviceInterfaceCount API.

--- a/plugins/modules/device_interface_info.py
+++ b/plugins/modules/device_interface_info.py
@@ -42,8 +42,8 @@ options:
     - Id path parameter. Interface ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetAllInterfaces
   description: Complete reference of the GetAllInterfaces API.

--- a/plugins/modules/device_interface_isis_info.py
+++ b/plugins/modules/device_interface_isis_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetISISInterfaces
   description: Complete reference of the GetISISInterfaces API.

--- a/plugins/modules/device_interface_ospf_info.py
+++ b/plugins/modules/device_interface_ospf_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetOSPFInterfaces
   description: Complete reference of the GetOSPFInterfaces API.

--- a/plugins/modules/device_reboot_apreboot.py
+++ b/plugins/modules/device_reboot_apreboot.py
@@ -21,8 +21,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless RebootAccessPoints
   description: Complete reference of the RebootAccessPoints API.

--- a/plugins/modules/device_reboot_apreboot_info.py
+++ b/plugins/modules/device_reboot_apreboot_info.py
@@ -24,8 +24,8 @@ options:
     - ParentTaskId query parameter. Task id of ap reboot request.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless GetAccessPointRebootTaskResult
   description: Complete reference of the GetAccessPointRebootTaskResult API.

--- a/plugins/modules/device_replacement.py
+++ b/plugins/modules/device_replacement.py
@@ -65,8 +65,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Replacement MarkDeviceForReplacement
   description: Complete reference of the MarkDeviceForReplacement API.

--- a/plugins/modules/device_replacement_count_info.py
+++ b/plugins/modules/device_replacement_count_info.py
@@ -27,8 +27,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Replacement ReturnReplacementDevicesCount
   description: Complete reference of the ReturnReplacementDevicesCount API.

--- a/plugins/modules/device_replacement_deploy.py
+++ b/plugins/modules/device_replacement_deploy.py
@@ -25,8 +25,8 @@ options:
     description: Device Replacement Deploy's replacementDeviceSerialNumber.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Replacement DeployDeviceReplacementWorkflow
   description: Complete reference of the DeployDeviceReplacementWorkflow API.

--- a/plugins/modules/device_replacement_info.py
+++ b/plugins/modules/device_replacement_info.py
@@ -71,8 +71,8 @@ options:
     - Limit query parameter.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Replacement ReturnListOfReplacementDevicesWithReplacementDetails
   description: Complete reference of the ReturnListOfReplacementDevicesWithReplacementDetails API.

--- a/plugins/modules/disassociate_site_to_network_profile.py
+++ b/plugins/modules/disassociate_site_to_network_profile.py
@@ -23,8 +23,8 @@ options:
     description: SiteId path parameter. Site Id to be associated.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Site Design Disassociate
   description: Complete reference of the Disassociate API.

--- a/plugins/modules/disasterrecovery_system_operationstatus_info.py
+++ b/plugins/modules/disasterrecovery_system_operationstatus_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     disaster_recovery.DisasterRecovery.disaster_recovery_operational_status,

--- a/plugins/modules/disasterrecovery_system_status_info.py
+++ b/plugins/modules/disasterrecovery_system_status_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     disaster_recovery.DisasterRecovery.disaster_recovery_status,

--- a/plugins/modules/discovery.py
+++ b/plugins/modules/discovery.py
@@ -214,8 +214,8 @@ options:
     description: Discovery's userNameList.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery StartDiscovery
   description: Complete reference of the StartDiscovery API.

--- a/plugins/modules/discovery_count_info.py
+++ b/plugins/modules/discovery_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetCountOfAllDiscoveryJobs
   description: Complete reference of the GetCountOfAllDiscoveryJobs API.

--- a/plugins/modules/discovery_device_count_info.py
+++ b/plugins/modules/discovery_device_count_info.py
@@ -30,8 +30,8 @@ options:
     - TaskId query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetDevicesDiscoveredById
   description: Complete reference of the GetDevicesDiscoveredById API.

--- a/plugins/modules/discovery_device_info.py
+++ b/plugins/modules/discovery_device_info.py
@@ -30,8 +30,8 @@ options:
     - TaskId query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetDiscoveredNetworkDevicesByDiscoveryId
   description: Complete reference of the GetDiscoveredNetworkDevicesByDiscoveryId API.

--- a/plugins/modules/discovery_device_range_info.py
+++ b/plugins/modules/discovery_device_range_info.py
@@ -38,8 +38,8 @@ options:
     - TaskId query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetDiscoveredDevicesByRange
   description: Complete reference of the GetDiscoveredDevicesByRange API.

--- a/plugins/modules/discovery_info.py
+++ b/plugins/modules/discovery_info.py
@@ -24,8 +24,8 @@ options:
     - Id path parameter. Discovery ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetDiscoveryById
   description: Complete reference of the GetDiscoveryById API.

--- a/plugins/modules/discovery_intent.py
+++ b/plugins/modules/discovery_intent.py
@@ -328,7 +328,7 @@ options:
         default: False
 requirements:
 - dnacentersdk == 2.6.10
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     discovery.Discovery.get_all_global_credentials_v2,

--- a/plugins/modules/discovery_job_info.py
+++ b/plugins/modules/discovery_job_info.py
@@ -44,8 +44,8 @@ options:
     - Id path parameter. Discovery ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetDiscoveryJobsByIP
   description: Complete reference of the GetDiscoveryJobsByIP API.

--- a/plugins/modules/discovery_range_delete.py
+++ b/plugins/modules/discovery_range_delete.py
@@ -23,8 +23,8 @@ options:
     description: StartIndex path parameter. Start index.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery DeleteDiscoveryBySpecifiedRange
   description: Complete reference of the DeleteDiscoveryBySpecifiedRange API.

--- a/plugins/modules/discovery_range_info.py
+++ b/plugins/modules/discovery_range_info.py
@@ -28,8 +28,8 @@ options:
     - RecordsToReturn path parameter. Number of records to return.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetDiscoveriesByRange
   description: Complete reference of the GetDiscoveriesByRange API.

--- a/plugins/modules/discovery_summary_info.py
+++ b/plugins/modules/discovery_summary_info.py
@@ -68,8 +68,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetNetworkDevicesFromDiscovery
   description: Complete reference of the GetNetworkDevicesFromDiscovery API.

--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -328,7 +328,7 @@ options:
         default: False
 requirements:
 - dnacentersdk == 2.6.10
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     discovery.Discovery.get_all_global_credentials_v2,

--- a/plugins/modules/dna_command_runner_keywords_info.py
+++ b/plugins/modules/dna_command_runner_keywords_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Command Runner GetAllKeywordsOfCLIsAcceptedByCommandRunner
   description: Complete reference of the GetAllKeywordsOfCLIsAcceptedByCommandRunner API.

--- a/plugins/modules/dnac_packages_info.py
+++ b/plugins/modules/dnac_packages_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Platform CiscoDNACenterPackagesSummary
   description: Complete reference of the CiscoDNACenterPackagesSummary API.

--- a/plugins/modules/dnacaap_management_execution_status_info.py
+++ b/plugins/modules/dnacaap_management_execution_status_info.py
@@ -24,8 +24,8 @@ options:
     - ExecutionId path parameter. Execution Id of API.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Task GetBusinessAPIExecutionDetails
   description: Complete reference of the GetBusinessAPIExecutionDetails API.

--- a/plugins/modules/endpoint_analytics_profiling_rules.py
+++ b/plugins/modules/endpoint_analytics_profiling_rules.py
@@ -114,8 +114,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     policy.Policy.create_a_profiling_rule,

--- a/plugins/modules/endpoint_analytics_profiling_rules_info.py
+++ b/plugins/modules/endpoint_analytics_profiling_rules_info.py
@@ -60,8 +60,8 @@ options:
     - RuleId path parameter. Unique rule identifier.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     policy.Policy.get_details_of_a_single_profiling_rule,

--- a/plugins/modules/eox_status_device_info.py
+++ b/plugins/modules/eox_status_device_info.py
@@ -26,8 +26,8 @@ options:
     - DeviceId path parameter. Device instance UUID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for EoX GetEoXDetailsPerDevice
   description: Complete reference of the GetEoXDetailsPerDevice API.

--- a/plugins/modules/eox_status_summary_info.py
+++ b/plugins/modules/eox_status_summary_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for EoX GetEoXSummary
   description: Complete reference of the GetEoXSummary API.

--- a/plugins/modules/event_api_status_info.py
+++ b/plugins/modules/event_api_status_info.py
@@ -24,8 +24,8 @@ options:
     - ExecutionId path parameter. Execution ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetStatusAPIForEvents
   description: Complete reference of the GetStatusAPIForEvents API.

--- a/plugins/modules/event_artifact_count_info.py
+++ b/plugins/modules/event_artifact_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management EventArtifactCount
   description: Complete reference of the EventArtifactCount API.

--- a/plugins/modules/event_artifact_info.py
+++ b/plugins/modules/event_artifact_info.py
@@ -48,8 +48,8 @@ options:
     - Search query parameter. Findd matches in name, description, eventId, type, category.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetEventArtifacts
   description: Complete reference of the GetEventArtifacts API.

--- a/plugins/modules/event_config_connector_types_info.py
+++ b/plugins/modules/event_config_connector_types_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetConnectorTypes
   description: Complete reference of the GetConnectorTypes API.

--- a/plugins/modules/event_count_info.py
+++ b/plugins/modules/event_count_info.py
@@ -28,8 +28,8 @@ options:
     - Tags query parameter. The registered Tags should be provided.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CountOfEvents
   description: Complete reference of the CountOfEvents API.

--- a/plugins/modules/event_email_config.py
+++ b/plugins/modules/event_email_config.py
@@ -62,8 +62,8 @@ options:
     description: To Email.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateEmailDestination
   description: Complete reference of the CreateEmailDestination API.

--- a/plugins/modules/event_email_config_create.py
+++ b/plugins/modules/event_email_config_create.py
@@ -61,8 +61,8 @@ options:
     description: To Email.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateEmailDestination
   description: Complete reference of the CreateEmailDestination API.

--- a/plugins/modules/event_email_config_info.py
+++ b/plugins/modules/event_email_config_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetEmailDestination
   description: Complete reference of the GetEmailDestination API.

--- a/plugins/modules/event_email_config_update.py
+++ b/plugins/modules/event_email_config_update.py
@@ -61,8 +61,8 @@ options:
     description: To Email.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management UpdateEmailDestination
   description: Complete reference of the UpdateEmailDestination API.

--- a/plugins/modules/event_info.py
+++ b/plugins/modules/event_info.py
@@ -44,8 +44,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetEvents
   description: Complete reference of the GetEvents API.

--- a/plugins/modules/event_series_audit_logs_info.py
+++ b/plugins/modules/event_series_audit_logs_info.py
@@ -122,8 +122,8 @@ options:
       values asc, desc.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetAuditLogRecords
   description: Complete reference of the GetAuditLogRecords API.

--- a/plugins/modules/event_series_audit_logs_parent_records_info.py
+++ b/plugins/modules/event_series_audit_logs_parent_records_info.py
@@ -118,8 +118,8 @@ options:
       values asc, desc.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetAuditLogParentRecords
   description: Complete reference of the GetAuditLogParentRecords API.

--- a/plugins/modules/event_series_audit_logs_summary_info.py
+++ b/plugins/modules/event_series_audit_logs_summary_info.py
@@ -106,8 +106,8 @@ options:
       mandatory).
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetAuditLogSummary
   description: Complete reference of the GetAuditLogSummary API.

--- a/plugins/modules/event_series_count_info.py
+++ b/plugins/modules/event_series_count_info.py
@@ -56,8 +56,8 @@ options:
     - Source query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CountOfNotifications
   description: Complete reference of the CountOfNotifications API.

--- a/plugins/modules/event_series_info.py
+++ b/plugins/modules/event_series_info.py
@@ -84,8 +84,8 @@ options:
     - SiteId query parameter. Site Id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetNotifications
   description: Complete reference of the GetNotifications API.

--- a/plugins/modules/event_snmp_config_info.py
+++ b/plugins/modules/event_snmp_config_info.py
@@ -40,8 +40,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetSNMPDestination
   description: Complete reference of the GetSNMPDestination API.

--- a/plugins/modules/event_subscription.py
+++ b/plugins/modules/event_subscription.py
@@ -94,8 +94,8 @@ options:
     description: Subscriptions query parameter. List of EventSubscriptionId's for removal.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateEventSubscriptions
   description: Complete reference of the CreateEventSubscriptions API.

--- a/plugins/modules/event_subscription_count_info.py
+++ b/plugins/modules/event_subscription_count_info.py
@@ -24,8 +24,8 @@ options:
     - EventIds query parameter. List of subscriptions related to the respective eventIds.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CountOfEventSubscriptions
   description: Complete reference of the CountOfEventSubscriptions API.

--- a/plugins/modules/event_subscription_details_email_info.py
+++ b/plugins/modules/event_subscription_details_email_info.py
@@ -44,8 +44,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetEmailSubscriptionDetails
   description: Complete reference of the GetEmailSubscriptionDetails API.

--- a/plugins/modules/event_subscription_details_rest_info.py
+++ b/plugins/modules/event_subscription_details_rest_info.py
@@ -48,8 +48,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetRestWebhookSubscriptionDetails
   description: Complete reference of the GetRestWebhookSubscriptionDetails API.

--- a/plugins/modules/event_subscription_details_syslog_info.py
+++ b/plugins/modules/event_subscription_details_syslog_info.py
@@ -46,8 +46,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetSyslogSubscriptionDetails
   description: Complete reference of the GetSyslogSubscriptionDetails API.

--- a/plugins/modules/event_subscription_email.py
+++ b/plugins/modules/event_subscription_email.py
@@ -106,8 +106,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateEmailEventSubscription
   description: Complete reference of the CreateEmailEventSubscription API.

--- a/plugins/modules/event_subscription_email_info.py
+++ b/plugins/modules/event_subscription_email_info.py
@@ -62,8 +62,8 @@ options:
     - Name query parameter. List of email subscriptions related to the respective name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetEmailEventSubscriptions
   description: Complete reference of the GetEmailEventSubscriptions API.

--- a/plugins/modules/event_subscription_info.py
+++ b/plugins/modules/event_subscription_info.py
@@ -40,8 +40,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetEventSubscriptions
   description: Complete reference of the GetEventSubscriptions API.

--- a/plugins/modules/event_subscription_rest.py
+++ b/plugins/modules/event_subscription_rest.py
@@ -90,8 +90,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateRestWebhookEventSubscription
   description: Complete reference of the CreateRestWebhookEventSubscription API.

--- a/plugins/modules/event_subscription_rest_info.py
+++ b/plugins/modules/event_subscription_rest_info.py
@@ -60,8 +60,8 @@ options:
     - Name query parameter. List of subscriptions related to the respective name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetRestWebhookEventSubscriptions
   description: Complete reference of the GetRestWebhookEventSubscriptions API.

--- a/plugins/modules/event_subscription_syslog.py
+++ b/plugins/modules/event_subscription_syslog.py
@@ -90,8 +90,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateSyslogEventSubscription
   description: Complete reference of the CreateSyslogEventSubscription API.

--- a/plugins/modules/event_subscription_syslog_info.py
+++ b/plugins/modules/event_subscription_syslog_info.py
@@ -60,8 +60,8 @@ options:
     - Name query parameter. List of subscriptions related to the respective name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetSyslogEventSubscriptions
   description: Complete reference of the GetSyslogEventSubscriptions API.

--- a/plugins/modules/event_syslog_config.py
+++ b/plugins/modules/event_syslog_config.py
@@ -36,8 +36,8 @@ options:
     description: Protocol.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateSyslogDestination
   description: Complete reference of the CreateSyslogDestination API.

--- a/plugins/modules/event_syslog_config_info.py
+++ b/plugins/modules/event_syslog_config_info.py
@@ -48,8 +48,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management GetSyslogDestination
   description: Complete reference of the GetSyslogDestination API.

--- a/plugins/modules/event_webhook_create.py
+++ b/plugins/modules/event_webhook_create.py
@@ -52,8 +52,8 @@ options:
     description: Required only for update webhook configuration.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateWebhookDestination
   description: Complete reference of the CreateWebhookDestination API.

--- a/plugins/modules/event_webhook_update.py
+++ b/plugins/modules/event_webhook_update.py
@@ -52,8 +52,8 @@ options:
     description: Required only for update webhook configuration.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management UpdateWebhookDestination
   description: Complete reference of the UpdateWebhookDestination API.

--- a/plugins/modules/execute_suggested_actions_commands.py
+++ b/plugins/modules/execute_suggested_actions_commands.py
@@ -27,8 +27,8 @@ options:
     description: Contains the actual value for the entity type that has been defined.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Issues ExecuteSuggestedActionsCommands
   description: Complete reference of the ExecuteSuggestedActionsCommands API.

--- a/plugins/modules/file_import.py
+++ b/plugins/modules/file_import.py
@@ -23,8 +23,8 @@ options:
     description: NameSpace path parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for File UploadFile
   description: Complete reference of the UploadFile API.

--- a/plugins/modules/file_info.py
+++ b/plugins/modules/file_info.py
@@ -36,8 +36,8 @@ options:
     - The filename used to save the download file.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for File DownloadAFileByFileId
   description: Complete reference of the DownloadAFileByFileId API.

--- a/plugins/modules/file_namespace_files_info.py
+++ b/plugins/modules/file_namespace_files_info.py
@@ -24,8 +24,8 @@ options:
     - NameSpace path parameter. A listing of fileId's.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for File GetListOfFiles
   description: Complete reference of the GetListOfFiles API.

--- a/plugins/modules/file_namespaces_info.py
+++ b/plugins/modules/file_namespaces_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for File GetListOfAvailableNamespaces
   description: Complete reference of the GetListOfAvailableNamespaces API.

--- a/plugins/modules/global_credential_delete.py
+++ b/plugins/modules/global_credential_delete.py
@@ -20,8 +20,8 @@ options:
     description: GlobalCredentialId path parameter. ID of global-credential.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery DeleteGlobalCredentialsById
   description: Complete reference of the DeleteGlobalCredentialsById API.

--- a/plugins/modules/global_credential_info.py
+++ b/plugins/modules/global_credential_info.py
@@ -40,8 +40,8 @@ options:
     - Id path parameter. Global Credential ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetCredentialSubTypeByCredentialId
   description: Complete reference of the GetCredentialSubTypeByCredentialId API.

--- a/plugins/modules/global_credential_update.py
+++ b/plugins/modules/global_credential_update.py
@@ -24,8 +24,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery UpdateGlobalCredentials
   description: Complete reference of the UpdateGlobalCredentials API.

--- a/plugins/modules/global_credential_v2.py
+++ b/plugins/modules/global_credential_v2.py
@@ -137,8 +137,8 @@ options:
         type: str
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateGlobalCredentialsV2
   description: Complete reference of the CreateGlobalCredentialsV2 API.

--- a/plugins/modules/global_credential_v2_info.py
+++ b/plugins/modules/global_credential_v2_info.py
@@ -22,8 +22,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetAllGlobalCredentialsV2
   description: Complete reference of the GetAllGlobalCredentialsV2 API.

--- a/plugins/modules/global_pool.py
+++ b/plugins/modules/global_pool.py
@@ -48,8 +48,8 @@ options:
         type: list
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings CreateGlobalPool
   description: Complete reference of the CreateGlobalPool API.

--- a/plugins/modules/global_pool_info.py
+++ b/plugins/modules/global_pool_info.py
@@ -28,8 +28,8 @@ options:
     - Limit query parameter. No of Global Pools to be retrieved.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings GetGlobalPool
   description: Complete reference of the GetGlobalPool API.

--- a/plugins/modules/golden_image_create.py
+++ b/plugins/modules/golden_image_create.py
@@ -30,8 +30,8 @@ options:
     description: SiteId in uuid format. For Global Site "-1" to be used.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) TagAsGoldenImage
   description: Complete reference of the TagAsGoldenImage API.

--- a/plugins/modules/golden_tag_image_delete.py
+++ b/plugins/modules/golden_tag_image_delete.py
@@ -32,8 +32,8 @@ options:
       Global site.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) RemoveGoldenTagForImage
   description: Complete reference of the RemoveGoldenTagForImage API.

--- a/plugins/modules/golden_tag_image_details_info.py
+++ b/plugins/modules/golden_tag_image_details_info.py
@@ -38,8 +38,8 @@ options:
     - ImageId path parameter. Image Id in uuid format.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) GetGoldenTagStatusOfAnImage
   description: Complete reference of the GetGoldenTagStatusOfAnImage API.

--- a/plugins/modules/http_read_credential.py
+++ b/plugins/modules/http_read_credential.py
@@ -48,8 +48,8 @@ options:
     description: Http Read Credential's username.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateHTTPReadCredentials
   description: Complete reference of the CreateHTTPReadCredentials API.

--- a/plugins/modules/http_write_credential.py
+++ b/plugins/modules/http_write_credential.py
@@ -48,8 +48,8 @@ options:
     description: Http Write Credential's username.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateHTTPWriteCredentials
   description: Complete reference of the CreateHTTPWriteCredentials API.

--- a/plugins/modules/integration_settings_instances_itsm.py
+++ b/plugins/modules/integration_settings_instances_itsm.py
@@ -48,8 +48,8 @@ options:
     description: Name of the setting instance.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for ITSM Integration CreateITSMIntegrationSetting
   description: Complete reference of the CreateITSMIntegrationSetting API.

--- a/plugins/modules/integration_settings_instances_itsm_info.py
+++ b/plugins/modules/integration_settings_instances_itsm_info.py
@@ -24,8 +24,8 @@ options:
     - InstanceId path parameter. Instance Id of the Integration setting instance.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for ITSM Integration GetITSMIntegrationSettingById
   description: Complete reference of the GetITSMIntegrationSettingById API.

--- a/plugins/modules/interface_info.py
+++ b/plugins/modules/interface_info.py
@@ -24,8 +24,8 @@ options:
     - InterfaceUuid path parameter. Interface ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices LegitOperationsForInterface
   description: Complete reference of the LegitOperationsForInterface API.

--- a/plugins/modules/interface_network_device_detail_info.py
+++ b/plugins/modules/interface_network_device_detail_info.py
@@ -28,8 +28,8 @@ options:
     - Name query parameter. Interface name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetInterfaceDetailsByDeviceIdAndInterfaceName
   description: Complete reference of the GetInterfaceDetailsByDeviceIdAndInterfaceName API.

--- a/plugins/modules/interface_network_device_info.py
+++ b/plugins/modules/interface_network_device_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceId path parameter. Device ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetInterfaceInfoById
   description: Complete reference of the GetInterfaceInfoById API.

--- a/plugins/modules/interface_network_device_range_info.py
+++ b/plugins/modules/interface_network_device_range_info.py
@@ -32,8 +32,8 @@ options:
     - RecordsToReturn path parameter. Number of records to return.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceInterfacesBySpecifiedRange
   description: Complete reference of the GetDeviceInterfacesBySpecifiedRange API.

--- a/plugins/modules/interface_operation_create.py
+++ b/plugins/modules/interface_operation_create.py
@@ -33,8 +33,8 @@ options:
     description: Payload.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices ClearMacAddressTable
   description: Complete reference of the ClearMacAddressTable API.

--- a/plugins/modules/interface_update.py
+++ b/plugins/modules/interface_update.py
@@ -39,8 +39,8 @@ options:
     description: Voice Vlan Id.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices UpdateInterfaceDetails
   description: Complete reference of the UpdateInterfaceDetails API.

--- a/plugins/modules/inventory_intent.py
+++ b/plugins/modules/inventory_intent.py
@@ -307,8 +307,8 @@ options:
             version_added: 6.12.0
 
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco Catalyst Center documentation for Devices AddDevice2
   description: Complete reference of the AddDevice2 API.

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -307,8 +307,8 @@ options:
             version_added: 6.12.0
 
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco Catalyst Center documentation for Devices AddDevice2
   description: Complete reference of the AddDevice2 API.

--- a/plugins/modules/issues_enrichment_details_info.py
+++ b/plugins/modules/issues_enrichment_details_info.py
@@ -22,8 +22,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Issues GetIssueEnrichmentDetails
   description: Complete reference of the GetIssueEnrichmentDetails API.

--- a/plugins/modules/issues_info.py
+++ b/plugins/modules/issues_info.py
@@ -58,8 +58,8 @@ options:
     - IssueStatus query parameter. The issue's status value (One of ACTIVE, IGNORED, RESOLVED).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Issues Issues
   description: Complete reference of the Issues API.

--- a/plugins/modules/itsm_cmdb_sync_status_info.py
+++ b/plugins/modules/itsm_cmdb_sync_status_info.py
@@ -34,8 +34,8 @@ options:
     - Date query parameter. Provide date in "YYYY-MM-DD" format.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for ITSM GetCMDBSyncStatus
   description: Complete reference of the GetCMDBSyncStatus API.

--- a/plugins/modules/itsm_integration_events_failed_info.py
+++ b/plugins/modules/itsm_integration_events_failed_info.py
@@ -24,8 +24,8 @@ options:
     - InstanceId query parameter. Instance Id of the failed event as in the Runtime Dashboard.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for ITSM GetFailedITSMEvents
   description: Complete reference of the GetFailedITSMEvents API.

--- a/plugins/modules/itsm_integration_events_retry.py
+++ b/plugins/modules/itsm_integration_events_retry.py
@@ -24,8 +24,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for ITSM RetryIntegrationEvents
   description: Complete reference of the RetryIntegrationEvents API.

--- a/plugins/modules/lan_automation_count_info.py
+++ b/plugins/modules/lan_automation_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for LAN Automation LANAutomationSessionCount
   description: Complete reference of the LANAutomationSessionCount API.

--- a/plugins/modules/lan_automation_create.py
+++ b/plugins/modules/lan_automation_create.py
@@ -63,8 +63,8 @@ options:
         type: bool
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for LAN Automation LANAutomationStart
   description: Complete reference of the LANAutomationStart API.

--- a/plugins/modules/lan_automation_delete.py
+++ b/plugins/modules/lan_automation_delete.py
@@ -20,8 +20,8 @@ options:
     description: Id path parameter. LAN Automation id can be obtained from /dna/intent/api/v1/lan-automation/status.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for LAN Automation LANAutomationStop
   description: Complete reference of the LANAutomationStop API.

--- a/plugins/modules/lan_automation_log_by_serial_number_info.py
+++ b/plugins/modules/lan_automation_log_by_serial_number_info.py
@@ -37,8 +37,8 @@ options:
       the remaining logs, please leave the query parameter blank.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for LAN Automation LANAutomationLogsForIndividualDevices
   description: Complete reference of the LANAutomationLogsForIndividualDevices API.

--- a/plugins/modules/lan_automation_log_info.py
+++ b/plugins/modules/lan_automation_log_info.py
@@ -34,8 +34,8 @@ options:
     - Id path parameter. LAN Automation session identifier.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for LAN Automation LANAutomationLog
   description: Complete reference of the LANAutomationLog API.

--- a/plugins/modules/lan_automation_status_info.py
+++ b/plugins/modules/lan_automation_status_info.py
@@ -34,8 +34,8 @@ options:
     - Id path parameter. LAN Automation session identifier.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for LAN Automation LANAutomationStatus
   description: Complete reference of the LANAutomationStatus API.

--- a/plugins/modules/license_device_count_info.py
+++ b/plugins/modules/license_device_count_info.py
@@ -40,8 +40,8 @@ options:
     - Smart_account_id query parameter. Smart account id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses DeviceCountDetails2
   description: Complete reference of the DeviceCountDetails2 API.

--- a/plugins/modules/license_device_deregistration.py
+++ b/plugins/modules/license_device_deregistration.py
@@ -21,8 +21,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses DeviceDeregistration2
   description: Complete reference of the DeviceDeregistration2 API.

--- a/plugins/modules/license_device_license_details_info.py
+++ b/plugins/modules/license_device_license_details_info.py
@@ -24,8 +24,8 @@ options:
     - Device_uuid path parameter. Id of device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses DeviceLicenseDetails2
   description: Complete reference of the DeviceLicenseDetails2 API.

--- a/plugins/modules/license_device_license_summary_info.py
+++ b/plugins/modules/license_device_license_summary_info.py
@@ -60,8 +60,8 @@ options:
     - Device_uuid query parameter. Id of device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses DeviceLicenseSummary2
   description: Complete reference of the DeviceLicenseSummary2 API.

--- a/plugins/modules/license_device_registration.py
+++ b/plugins/modules/license_device_registration.py
@@ -24,8 +24,8 @@ options:
     description: Virtual_account_name path parameter. Name of virtual account.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses DeviceRegistration2
   description: Complete reference of the DeviceRegistration2 API.

--- a/plugins/modules/license_smart_account_details_info.py
+++ b/plugins/modules/license_smart_account_details_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses SmartAccountDetails
   description: Complete reference of the SmartAccountDetails API.

--- a/plugins/modules/license_term_details_info.py
+++ b/plugins/modules/license_term_details_info.py
@@ -34,8 +34,8 @@ options:
     - Device_type query parameter. Type of device like router, switch, wireless or ise.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses LicenseTermDetails2
   description: Complete reference of the LicenseTermDetails2 API.

--- a/plugins/modules/license_usage_details_info.py
+++ b/plugins/modules/license_usage_details_info.py
@@ -34,8 +34,8 @@ options:
     - Device_type query parameter. Type of device like router, switch, wireless or ise.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses LicenseUsageDetails2
   description: Complete reference of the LicenseUsageDetails2 API.

--- a/plugins/modules/license_virtual_account_change.py
+++ b/plugins/modules/license_virtual_account_change.py
@@ -27,8 +27,8 @@ options:
     description: Virtual_account_name path parameter. Name of target virtual account.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses ChangeVirtualAccount2
   description: Complete reference of the ChangeVirtualAccount2 API.

--- a/plugins/modules/license_virtual_account_details_info.py
+++ b/plugins/modules/license_virtual_account_details_info.py
@@ -24,8 +24,8 @@ options:
     - Smart_account_id path parameter. Id of smart account.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Licenses VirtualAccountDetails2
   description: Complete reference of the VirtualAccountDetails2 API.

--- a/plugins/modules/netconf_credential.py
+++ b/plugins/modules/netconf_credential.py
@@ -39,8 +39,8 @@ options:
     description: Netconf Credential's netconfPort.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateNetconfCredentials
   description: Complete reference of the CreateNetconfCredentials API.

--- a/plugins/modules/network_create.py
+++ b/plugins/modules/network_create.py
@@ -134,8 +134,8 @@ options:
       the network settings.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings CreateNetwork
   description: Complete reference of the CreateNetwork API.

--- a/plugins/modules/network_device.py
+++ b/plugins/modules/network_device.py
@@ -117,8 +117,8 @@ options:
     description: Network Device's userName.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices AddDevice2
   description: Complete reference of the AddDevice2 API.

--- a/plugins/modules/network_device_by_ip_info.py
+++ b/plugins/modules/network_device_by_ip_info.py
@@ -24,8 +24,8 @@ options:
     - IpAddress path parameter. Device IP address.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetNetworkDeviceByIP
   description: Complete reference of the GetNetworkDeviceByIP API.

--- a/plugins/modules/network_device_by_serial_number_info.py
+++ b/plugins/modules/network_device_by_serial_number_info.py
@@ -24,8 +24,8 @@ options:
     - SerialNumber path parameter. Device serial number.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceBySerialNumber
   description: Complete reference of the GetDeviceBySerialNumber API.

--- a/plugins/modules/network_device_chassis_details_info.py
+++ b/plugins/modules/network_device_chassis_details_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceId path parameter. Device ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetChassisDetailsForDevice
   description: Complete reference of the GetChassisDetailsForDevice API.

--- a/plugins/modules/network_device_config_count_info.py
+++ b/plugins/modules/network_device_config_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceConfigCount
   description: Complete reference of the GetDeviceConfigCount API.

--- a/plugins/modules/network_device_config_info.py
+++ b/plugins/modules/network_device_config_info.py
@@ -26,8 +26,8 @@ options:
     - NetworkDeviceId path parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceConfigById
   description: Complete reference of the GetDeviceConfigById API.

--- a/plugins/modules/network_device_count_info.py
+++ b/plugins/modules/network_device_count_info.py
@@ -28,8 +28,8 @@ options:
     - DeviceId path parameter. Device ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceCount2
   description: Complete reference of the GetDeviceCount2 API.

--- a/plugins/modules/network_device_custom_prompt.py
+++ b/plugins/modules/network_device_custom_prompt.py
@@ -25,8 +25,8 @@ options:
     description: Username Prompt.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for System Settings CustomPromptPOSTAPI
   description: Complete reference of the CustomPromptPOSTAPI API.

--- a/plugins/modules/network_device_custom_prompt_info.py
+++ b/plugins/modules/network_device_custom_prompt_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for System Settings CustomPromptSupportGETAPI
   description: Complete reference of the CustomPromptSupportGETAPI API.

--- a/plugins/modules/network_device_equipment_info.py
+++ b/plugins/modules/network_device_equipment_info.py
@@ -30,8 +30,8 @@ options:
       If no type is mentioned, All equipments are fetched for the device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices ReturnPowerSupplyFanDetailsForTheGivenDevice
   description: Complete reference of the ReturnPowerSupplyFanDetailsForTheGivenDevice API.

--- a/plugins/modules/network_device_export.py
+++ b/plugins/modules/network_device_export.py
@@ -34,8 +34,8 @@ options:
     description: Network Device Export's password.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices ExportDeviceList
   description: Complete reference of the ExportDeviceList API.

--- a/plugins/modules/network_device_functional_capability_info.py
+++ b/plugins/modules/network_device_functional_capability_info.py
@@ -37,8 +37,8 @@ options:
     - Id path parameter. Functional Capability UUID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetFunctionalCapabilityById
   description: Complete reference of the GetFunctionalCapabilityById API.

--- a/plugins/modules/network_device_global_polling_interval_info.py
+++ b/plugins/modules/network_device_global_polling_interval_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetPollingIntervalForAllDevices
   description: Complete reference of the GetPollingIntervalForAllDevices API.

--- a/plugins/modules/network_device_info.py
+++ b/plugins/modules/network_device_info.py
@@ -190,8 +190,8 @@ options:
     - Limit query parameter. 1 <= limit <= 500 max. No. Of devices to be returned in the result.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceByID
   description: Complete reference of the GetDeviceByID API.

--- a/plugins/modules/network_device_interface_neighbor_info.py
+++ b/plugins/modules/network_device_interface_neighbor_info.py
@@ -28,8 +28,8 @@ options:
     - InterfaceUuid path parameter. Instanceuuid of interface.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetConnectedDeviceDetail
   description: Complete reference of the GetConnectedDeviceDetail API.

--- a/plugins/modules/network_device_interface_poe_info.py
+++ b/plugins/modules/network_device_interface_poe_info.py
@@ -31,8 +31,8 @@ options:
     - InterfaceNameList query parameter. Comma seperated interface names.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices ReturnsPOEInterfaceDetailsForTheDevice
   description: Complete reference of the ReturnsPOEInterfaceDetailsForTheDevice API.

--- a/plugins/modules/network_device_inventory_insight_link_mismatch_info.py
+++ b/plugins/modules/network_device_inventory_insight_link_mismatch_info.py
@@ -44,8 +44,8 @@ options:
     - Order query parameter. Order. Value can be asc or desc. Default value is asc.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices InventoryInsightDeviceLinkMismatchAPI
   description: Complete reference of the InventoryInsightDeviceLinkMismatchAPI API.

--- a/plugins/modules/network_device_lexicographically_sorted_info.py
+++ b/plugins/modules/network_device_lexicographically_sorted_info.py
@@ -108,8 +108,8 @@ options:
     - Limit query parameter.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceValuesThatMatchFullyOrPartiallyAnAttribute
   description: Complete reference of the GetDeviceValuesThatMatchFullyOrPartiallyAnAttribute API.

--- a/plugins/modules/network_device_linecard_details_info.py
+++ b/plugins/modules/network_device_linecard_details_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceUuid path parameter. Instanceuuid of device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetLinecardDetails
   description: Complete reference of the GetLinecardDetails API.

--- a/plugins/modules/network_device_meraki_organization_info.py
+++ b/plugins/modules/network_device_meraki_organization_info.py
@@ -24,8 +24,8 @@ options:
     - Id path parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetOrganizationListForMeraki
   description: Complete reference of the GetOrganizationListForMeraki API.

--- a/plugins/modules/network_device_module_count_info.py
+++ b/plugins/modules/network_device_module_count_info.py
@@ -44,8 +44,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetModuleCount
   description: Complete reference of the GetModuleCount API.

--- a/plugins/modules/network_device_module_info.py
+++ b/plugins/modules/network_device_module_info.py
@@ -58,8 +58,8 @@ options:
     - Id path parameter. Module id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetModuleInfoById
   description: Complete reference of the GetModuleInfoById API.

--- a/plugins/modules/network_device_poe_info.py
+++ b/plugins/modules/network_device_poe_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceUuid path parameter. Uuid of the device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices POEDetails
   description: Complete reference of the POEDetails API.

--- a/plugins/modules/network_device_polling_interval_info.py
+++ b/plugins/modules/network_device_polling_interval_info.py
@@ -24,8 +24,8 @@ options:
     - Id path parameter. Device ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetPollingIntervalById
   description: Complete reference of the GetPollingIntervalById API.

--- a/plugins/modules/network_device_range_info.py
+++ b/plugins/modules/network_device_range_info.py
@@ -30,8 +30,8 @@ options:
     - RecordsToReturn path parameter. Number of records to return 1<= recordsToReturn <= 500.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetNetworkDeviceByPaginationRange
   description: Complete reference of the GetNetworkDeviceByPaginationRange API.

--- a/plugins/modules/network_device_register_for_wsa_info.py
+++ b/plugins/modules/network_device_register_for_wsa_info.py
@@ -30,8 +30,8 @@ options:
     - Macaddress query parameter. Mac addres of the device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDevicesRegisteredForWSANotification
   description: Complete reference of the GetDevicesRegisteredForWSANotification API.

--- a/plugins/modules/network_device_stack_details_info.py
+++ b/plugins/modules/network_device_stack_details_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceId path parameter. Device ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetStackDetailsForDevice
   description: Complete reference of the GetStackDetailsForDevice API.

--- a/plugins/modules/network_device_summary_info.py
+++ b/plugins/modules/network_device_summary_info.py
@@ -24,8 +24,8 @@ options:
     - Id path parameter. Device ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceSummary
   description: Complete reference of the GetDeviceSummary API.

--- a/plugins/modules/network_device_supervisor_card_details_info.py
+++ b/plugins/modules/network_device_supervisor_card_details_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceUuid path parameter. Instanceuuid of device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetSupervisorCardDetail
   description: Complete reference of the GetSupervisorCardDetail API.

--- a/plugins/modules/network_device_sync.py
+++ b/plugins/modules/network_device_sync.py
@@ -27,8 +27,8 @@ options:
     elements: dict
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices SyncDevices
   description: Complete reference of the SyncDevices API.

--- a/plugins/modules/network_device_update_role.py
+++ b/plugins/modules/network_device_update_role.py
@@ -26,8 +26,8 @@ options:
     description: Network Device Update Role's roleSource.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices UpdateDeviceRole
   description: Complete reference of the UpdateDeviceRole API.

--- a/plugins/modules/network_device_user_defined_field.py
+++ b/plugins/modules/network_device_user_defined_field.py
@@ -28,8 +28,8 @@ options:
     description: Name of UDF.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices CreateUserDefinedField
   description: Complete reference of the CreateUserDefinedField API.

--- a/plugins/modules/network_device_user_defined_field_info.py
+++ b/plugins/modules/network_device_user_defined_field_info.py
@@ -30,8 +30,8 @@ options:
     - Name query parameter. Comma-seperated name(s) used for search/filtering.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetAllUserDefinedFields
   description: Complete reference of the GetAllUserDefinedFields API.

--- a/plugins/modules/network_device_vlan_info.py
+++ b/plugins/modules/network_device_vlan_info.py
@@ -28,8 +28,8 @@ options:
     - InterfaceType query parameter. Vlan assocaited with sub-interface.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetDeviceInterfaceVLANs
   description: Complete reference of the GetDeviceInterfaceVLANs API.

--- a/plugins/modules/network_device_wireless_lan_info.py
+++ b/plugins/modules/network_device_wireless_lan_info.py
@@ -24,8 +24,8 @@ options:
     - Id path parameter. Device ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetWirelessLanControllerDetailsById
   description: Complete reference of the GetWirelessLanControllerDetailsById API.

--- a/plugins/modules/network_device_with_snmp_v3_des_info.py
+++ b/plugins/modules/network_device_with_snmp_v3_des_info.py
@@ -42,8 +42,8 @@ options:
     - Order query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices ReturnsDevicesAddedToCiscoDNACenterWithSnmpV3DES
   description: Complete reference of the ReturnsDevicesAddedToCiscoDNACenterWithSnmpV3DES API.

--- a/plugins/modules/network_info.py
+++ b/plugins/modules/network_info.py
@@ -24,8 +24,8 @@ options:
     - SiteId query parameter. Site id to get the network settings associated with the site.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings GetNetwork
   description: Complete reference of the GetNetwork API.

--- a/plugins/modules/network_settings_intent.py
+++ b/plugins/modules/network_settings_intent.py
@@ -318,7 +318,7 @@ options:
             type: str
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     network_settings.NetworkSettings.create_global_pool,

--- a/plugins/modules/network_settings_workflow_manager.py
+++ b/plugins/modules/network_settings_workflow_manager.py
@@ -318,7 +318,7 @@ options:
             type: str
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     network_settings.NetworkSettings.create_global_pool,

--- a/plugins/modules/network_update.py
+++ b/plugins/modules/network_update.py
@@ -131,8 +131,8 @@ options:
       is associated with the site.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings UpdateNetwork
   description: Complete reference of the UpdateNetwork API.

--- a/plugins/modules/network_v2.py
+++ b/plugins/modules/network_v2.py
@@ -134,8 +134,8 @@ options:
       the network settings.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings CreateNetworkV2
   description: Complete reference of the CreateNetworkV2 API.

--- a/plugins/modules/network_v2_info.py
+++ b/plugins/modules/network_v2_info.py
@@ -24,8 +24,8 @@ options:
     - SiteId query parameter. Site Id to get the network settings associated with the site.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings GetNetworkV2
   description: Complete reference of the GetNetworkV2 API.

--- a/plugins/modules/nfv_profile.py
+++ b/plugins/modules/nfv_profile.py
@@ -147,8 +147,8 @@ options:
     description: Name of the profile to create NFV profile.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Site Design CreateNFVProfile
   description: Complete reference of the CreateNFVProfile API.

--- a/plugins/modules/nfv_profile_info.py
+++ b/plugins/modules/nfv_profile_info.py
@@ -36,8 +36,8 @@ options:
     - Name query parameter. Name of network profile to be retrieved.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Site Design GetNFVProfile
   description: Complete reference of the GetNFVProfile API.

--- a/plugins/modules/nfv_provision.py
+++ b/plugins/modules/nfv_provision.py
@@ -375,8 +375,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Site Design ProvisionNFV
   description: Complete reference of the ProvisionNFV API.

--- a/plugins/modules/nfv_provision_detail_info.py
+++ b/plugins/modules/nfv_provision_detail_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceIp query parameter. Device to which the provisioning detail has to be retrieved.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Site Design GetDeviceDetailsByIP
   description: Complete reference of the GetDeviceDetailsByIP API.

--- a/plugins/modules/nfv_provision_details.py
+++ b/plugins/modules/nfv_provision_details.py
@@ -23,8 +23,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Site Design NFVProvisioningDetail
   description: Complete reference of the NFVProvisioningDetail API.

--- a/plugins/modules/path_trace.py
+++ b/plugins/modules/path_trace.py
@@ -49,8 +49,8 @@ options:
     description: Source Port.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Path Trace InitiateANewPathtrace
   description: Complete reference of the InitiateANewPathtrace API.

--- a/plugins/modules/path_trace_info.py
+++ b/plugins/modules/path_trace_info.py
@@ -86,8 +86,8 @@ options:
     - FlowAnalysisId path parameter. Flow analysis request id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Path Trace RetrievesPreviousPathtrace
   description: Complete reference of the RetrievesPreviousPathtrace API.

--- a/plugins/modules/planned_access_points_info.py
+++ b/plugins/modules/planned_access_points_info.py
@@ -36,8 +36,8 @@ options:
     - Radios query parameter. Inlcude planned radio details.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Devices GetPlannedAccessPointsForFloor
   description: Complete reference of the GetPlannedAccessPointsForFloor API.

--- a/plugins/modules/platform_nodes_configuration_summary_info.py
+++ b/plugins/modules/platform_nodes_configuration_summary_info.py
@@ -23,8 +23,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Platform Configuration CiscoDNACenterNodesConfigurationSummary
   description: Complete reference of the CiscoDNACenterNodesConfigurationSummary API.

--- a/plugins/modules/platform_release_summary_info.py
+++ b/plugins/modules/platform_release_summary_info.py
@@ -22,8 +22,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Platform Configuration CiscoDNACenterReleaseSummary
   description: Complete reference of the CiscoDNACenterReleaseSummary API.

--- a/plugins/modules/pnp_device.py
+++ b/plugins/modules/pnp_device.py
@@ -823,8 +823,8 @@ options:
         type: str
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) AddDevice
   description: Complete reference of the AddDevice API.

--- a/plugins/modules/pnp_device_authorize.py
+++ b/plugins/modules/pnp_device_authorize.py
@@ -21,8 +21,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for  AuthorizeDevice
   description: Complete reference of the AuthorizeDevice API.

--- a/plugins/modules/pnp_device_claim.py
+++ b/plugins/modules/pnp_device_claim.py
@@ -77,8 +77,8 @@ options:
     description: Pnp Device Claim's workflowId.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) ClaimDevice
   description: Complete reference of the ClaimDevice API.

--- a/plugins/modules/pnp_device_claim_to_site.py
+++ b/plugins/modules/pnp_device_claim_to_site.py
@@ -80,8 +80,8 @@ options:
     description: For Catalyst 9800 WLC.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) ClaimADeviceToASite
   description: Complete reference of the ClaimADeviceToASite API.

--- a/plugins/modules/pnp_device_config_preview.py
+++ b/plugins/modules/pnp_device_config_preview.py
@@ -26,8 +26,8 @@ options:
     description: Pnp Device Config Preview's type.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) PreviewConfig
   description: Complete reference of the PreviewConfig API.

--- a/plugins/modules/pnp_device_count_info.py
+++ b/plugins/modules/pnp_device_count_info.py
@@ -89,8 +89,8 @@ options:
     - LastContact query parameter. Device Has Contacted lastContact > 0.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetDeviceCount
   description: Complete reference of the GetDeviceCount API.

--- a/plugins/modules/pnp_device_history_info.py
+++ b/plugins/modules/pnp_device_history_info.py
@@ -33,8 +33,8 @@ options:
     - SortOrder query parameter. Sort Order Ascending (asc) or Descending (des).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetDeviceHistory
   description: Complete reference of the GetDeviceHistory API.

--- a/plugins/modules/pnp_device_import.py
+++ b/plugins/modules/pnp_device_import.py
@@ -823,8 +823,8 @@ options:
         type: dict
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) ImportDevicesInBulk
   description: Complete reference of the ImportDevicesInBulk API.

--- a/plugins/modules/pnp_device_info.py
+++ b/plugins/modules/pnp_device_info.py
@@ -126,8 +126,8 @@ options:
     - Id path parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetDeviceById
   description: Complete reference of the GetDeviceById API.

--- a/plugins/modules/pnp_device_reset.py
+++ b/plugins/modules/pnp_device_reset.py
@@ -59,8 +59,8 @@ options:
     description: Pnp Device Reset's workflowId.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) ResetDevice
   description: Complete reference of the ResetDevice API.

--- a/plugins/modules/pnp_device_unclaim.py
+++ b/plugins/modules/pnp_device_unclaim.py
@@ -21,8 +21,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) UnClaimDevice
   description: Complete reference of the UnClaimDevice API.

--- a/plugins/modules/pnp_global_settings.py
+++ b/plugins/modules/pnp_global_settings.py
@@ -158,8 +158,8 @@ options:
     description: Pnp Global Settings's version.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) UpdatePnPGlobalSettings
   description: Complete reference of the UpdatePnPGlobalSettings API.

--- a/plugins/modules/pnp_global_settings_info.py
+++ b/plugins/modules/pnp_global_settings_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetPnPGlobalSettings
   description: Complete reference of the GetPnPGlobalSettings API.

--- a/plugins/modules/pnp_intent.py
+++ b/plugins/modules/pnp_intent.py
@@ -158,7 +158,7 @@ options:
           - TYPICAL
 requirements:
   - dnacentersdk == 2.6.10
-  - python >= 3.5
+  - python >= 3.9
 notes:
   - SDK Method used are device_onboarding_pnp.DeviceOnboardingPnp.add_device,
     device_onboarding_pnp.DeviceOnboardingPnp.get_device_list,

--- a/plugins/modules/pnp_server_profile_update.py
+++ b/plugins/modules/pnp_server_profile_update.py
@@ -99,8 +99,8 @@ options:
     description: Pnp Server Profile Update's virtualAccountId.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) UpdatePnPServerProfile
   description: Complete reference of the UpdatePnPServerProfile API.

--- a/plugins/modules/pnp_smart_account_domains_info.py
+++ b/plugins/modules/pnp_smart_account_domains_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetSmartAccountList
   description: Complete reference of the GetSmartAccountList API.

--- a/plugins/modules/pnp_virtual_account_add.py
+++ b/plugins/modules/pnp_virtual_account_add.py
@@ -100,8 +100,8 @@ options:
     description: Pnp Virtual Account Add's virtualAccountId.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) AddVirtualAccount
   description: Complete reference of the AddVirtualAccount API.

--- a/plugins/modules/pnp_virtual_account_deregister.py
+++ b/plugins/modules/pnp_virtual_account_deregister.py
@@ -26,8 +26,8 @@ options:
     description: Name query parameter. Virtual Account Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) DeregisterVirtualAccount
   description: Complete reference of the DeregisterVirtualAccount API.

--- a/plugins/modules/pnp_virtual_account_devices_sync.py
+++ b/plugins/modules/pnp_virtual_account_devices_sync.py
@@ -99,8 +99,8 @@ options:
     description: Pnp Virtual Account Devices Sync's virtualAccountId.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) SyncVirtualAccountDevices
   description: Complete reference of the SyncVirtualAccountDevices API.

--- a/plugins/modules/pnp_virtual_account_sync_result_info.py
+++ b/plugins/modules/pnp_virtual_account_sync_result_info.py
@@ -28,8 +28,8 @@ options:
     - Name path parameter. Virtual Account Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetSyncResultForVirtualAccount
   description: Complete reference of the GetSyncResultForVirtualAccount API.

--- a/plugins/modules/pnp_virtual_accounts_info.py
+++ b/plugins/modules/pnp_virtual_accounts_info.py
@@ -24,8 +24,8 @@ options:
     - Domain path parameter. Smart Account Domain.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetVirtualAccountList
   description: Complete reference of the GetVirtualAccountList API.

--- a/plugins/modules/pnp_workflow.py
+++ b/plugins/modules/pnp_workflow.py
@@ -128,8 +128,8 @@ options:
     description: Pnp Workflow's version.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) AddAWorkflow
   description: Complete reference of the AddAWorkflow API.

--- a/plugins/modules/pnp_workflow_count_info.py
+++ b/plugins/modules/pnp_workflow_count_info.py
@@ -25,8 +25,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetWorkflowCount
   description: Complete reference of the GetWorkflowCount API.

--- a/plugins/modules/pnp_workflow_info.py
+++ b/plugins/modules/pnp_workflow_info.py
@@ -55,8 +55,8 @@ options:
     - Id path parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Device Onboarding (PnP) GetWorkflowById
   description: Complete reference of the GetWorkflowById API.

--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -158,7 +158,7 @@ options:
           - TYPICAL
 requirements:
   - dnacentersdk == 2.6.10
-  - python >= 3.5
+  - python >= 3.9
 notes:
   - SDK Method used are device_onboarding_pnp.DeviceOnboardingPnp.add_device,
     device_onboarding_pnp.DeviceOnboardingPnp.get_device_list,

--- a/plugins/modules/profiling_rules_count_info.py
+++ b/plugins/modules/profiling_rules_count_info.py
@@ -29,8 +29,8 @@ options:
     - IncludeDeleted query parameter. Flag to indicate whether deleted rules should be part of the records fetched.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     policy.Policy.get_count_of_profiling_rules,

--- a/plugins/modules/profiling_rules_in_bulk_create.py
+++ b/plugins/modules/profiling_rules_in_bulk_create.py
@@ -121,8 +121,8 @@ options:
         type: list
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     policy.Policy.import_profiling_rules_in_bulk,

--- a/plugins/modules/projects_details_info.py
+++ b/plugins/modules/projects_details_info.py
@@ -40,8 +40,8 @@ options:
     - SortOrder query parameter. Sort Order Ascending (asc) or Descending (dsc).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates GetProjectsDetails
   description: Complete reference of the GetProjectsDetails API.

--- a/plugins/modules/provision_intent.py
+++ b/plugins/modules/provision_intent.py
@@ -74,7 +74,7 @@ options:
 
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Methods used are
     sites.Sites.get_site,

--- a/plugins/modules/provision_workflow_manager.py
+++ b/plugins/modules/provision_workflow_manager.py
@@ -75,7 +75,7 @@ options:
 
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Methods used are
     sites.Sites.get_site,

--- a/plugins/modules/qos_device_interface.py
+++ b/plugins/modules/qos_device_interface.py
@@ -70,8 +70,8 @@ options:
         type: list
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy CreateQosDeviceInterfaceInfo
   description: Complete reference of the CreateQosDeviceInterfaceInfo API.

--- a/plugins/modules/qos_device_interface_info.py
+++ b/plugins/modules/qos_device_interface_info.py
@@ -24,8 +24,8 @@ options:
     - NetworkDeviceId query parameter. Network device id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetQosDeviceInterfaceInfo
   description: Complete reference of the GetQosDeviceInterfaceInfo API.

--- a/plugins/modules/qos_device_interface_info_count_info.py
+++ b/plugins/modules/qos_device_interface_info_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Application Policy GetQosDeviceInterfaceInfoCount
   description: Complete reference of the GetQosDeviceInterfaceInfoCount API.

--- a/plugins/modules/reports.py
+++ b/plugins/modules/reports.py
@@ -103,8 +103,8 @@ options:
     description: Version of viewgroup for the report.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Reports CreateOrScheduleAReport
   description: Complete reference of the CreateOrScheduleAReport API.

--- a/plugins/modules/reports_executions_info.py
+++ b/plugins/modules/reports_executions_info.py
@@ -44,8 +44,8 @@ options:
     - The filename used to save the download file.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Reports DownloadReportContent
   description: Complete reference of the DownloadReportContent API.

--- a/plugins/modules/reports_info.py
+++ b/plugins/modules/reports_info.py
@@ -34,8 +34,8 @@ options:
     - ReportId path parameter. ReportId of report.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Reports GetAScheduledReport
   description: Complete reference of the GetAScheduledReport API.

--- a/plugins/modules/reports_view_group_info.py
+++ b/plugins/modules/reports_view_group_info.py
@@ -28,8 +28,8 @@ options:
     - ViewGroupId path parameter. ViewGroupId of viewgroup.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Reports GetAllViewGroups
   description: Complete reference of the GetAllViewGroups API.

--- a/plugins/modules/reports_view_group_view_info.py
+++ b/plugins/modules/reports_view_group_view_info.py
@@ -30,8 +30,8 @@ options:
     - ViewId path parameter. View id of view.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Reports GetViewDetailsForAGivenViewGroup_View
   description: Complete reference of the GetViewDetailsForAGivenViewGroup_View API.

--- a/plugins/modules/reserve_ip_subpool.py
+++ b/plugins/modules/reserve_ip_subpool.py
@@ -94,8 +94,8 @@ options:
     description: Type of the reserve ip sub pool.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings ReserveIPSubpool
   description: Complete reference of the ReserveIPSubpool API.

--- a/plugins/modules/reserve_ip_subpool_create.py
+++ b/plugins/modules/reserve_ip_subpool_create.py
@@ -88,8 +88,8 @@ options:
     description: Type of the reserve ip sub pool.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings ReserveIPSubpool
   description: Complete reference of the ReserveIPSubpool API.

--- a/plugins/modules/reserve_ip_subpool_delete.py
+++ b/plugins/modules/reserve_ip_subpool_delete.py
@@ -20,8 +20,8 @@ options:
     description: Id path parameter. Id of reserve ip subpool to be deleted.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings ReleaseReserveIPSubpool
   description: Complete reference of the ReleaseReserveIPSubpool API.

--- a/plugins/modules/reserve_ip_subpool_info.py
+++ b/plugins/modules/reserve_ip_subpool_info.py
@@ -32,8 +32,8 @@ options:
     - Limit query parameter. No of Global Pools to be retrieved.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings GetReserveIPSubpool
   description: Complete reference of the GetReserveIPSubpool API.

--- a/plugins/modules/reserve_ip_subpool_update.py
+++ b/plugins/modules/reserve_ip_subpool_update.py
@@ -72,8 +72,8 @@ options:
     description: Slaac Support.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings UpdateReserveIPSubpool
   description: Complete reference of the UpdateReserveIPSubpool API.

--- a/plugins/modules/role_permissions_info.py
+++ b/plugins/modules/role_permissions_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for User and Roles GetPermissionsAPI
   description: Complete reference of the GetPermissionsAPI API.

--- a/plugins/modules/roles_info.py
+++ b/plugins/modules/roles_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for User and Roles GetRolesAPI
   description: Complete reference of the GetRolesAPI API.

--- a/plugins/modules/sda_count_info.py
+++ b/plugins/modules/sda_count_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     sda.Sda.get_sda_fabric_count,

--- a/plugins/modules/sda_device_info.py
+++ b/plugins/modules/sda_device_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceManagementIpAddress query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetDeviceInfoFromSDAFabric
   description: Complete reference of the GetDeviceInfoFromSDAFabric API.

--- a/plugins/modules/sda_device_role_info.py
+++ b/plugins/modules/sda_device_role_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceManagementIpAddress query parameter. Device Management IP Address.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetDeviceRoleInSDAFabric
   description: Complete reference of the GetDeviceRoleInSDAFabric API.

--- a/plugins/modules/sda_fabric.py
+++ b/plugins/modules/sda_fabric.py
@@ -21,8 +21,8 @@ options:
     description: FabricName query parameter. Fabric Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     sda.Sda.add_fabric,

--- a/plugins/modules/sda_fabric_authentication_profile.py
+++ b/plugins/modules/sda_fabric_authentication_profile.py
@@ -34,8 +34,8 @@ options:
     description: SiteNameHierarchy query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddDefaultAuthenticationTemplateInSDAFabric
   description: Complete reference of the AddDefaultAuthenticationTemplateInSDAFabric API.

--- a/plugins/modules/sda_fabric_authentication_profile_info.py
+++ b/plugins/modules/sda_fabric_authentication_profile_info.py
@@ -29,8 +29,8 @@ options:
     - AuthenticateTemplateName query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetDefaultAuthenticationProfileFromSDAFabric
   description: Complete reference of the GetDefaultAuthenticationProfileFromSDAFabric API.

--- a/plugins/modules/sda_fabric_border_device.py
+++ b/plugins/modules/sda_fabric_border_device.py
@@ -125,8 +125,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddBorderDeviceInSDAFabric
   description: Complete reference of the AddBorderDeviceInSDAFabric API.

--- a/plugins/modules/sda_fabric_border_device_info.py
+++ b/plugins/modules/sda_fabric_border_device_info.py
@@ -25,8 +25,8 @@ options:
     - DeviceManagementIpAddress query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetBorderDeviceDetailFromSDAFabric
   description: Complete reference of the GetBorderDeviceDetailFromSDAFabric API.

--- a/plugins/modules/sda_fabric_control_plane_device.py
+++ b/plugins/modules/sda_fabric_control_plane_device.py
@@ -31,8 +31,8 @@ options:
     type: str
     version_added: 4.0.0
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddControlPlaneDeviceInSDAFabric
   description: Complete reference of the AddControlPlaneDeviceInSDAFabric API.

--- a/plugins/modules/sda_fabric_control_plane_device_info.py
+++ b/plugins/modules/sda_fabric_control_plane_device_info.py
@@ -25,8 +25,8 @@ options:
     - DeviceManagementIpAddress query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetControlPlaneDeviceFromSDAFabric
   description: Complete reference of the GetControlPlaneDeviceFromSDAFabric API.

--- a/plugins/modules/sda_fabric_edge_device.py
+++ b/plugins/modules/sda_fabric_edge_device.py
@@ -26,8 +26,8 @@ options:
     type: str
     version_added: 4.0.0
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddEdgeDeviceInSDAFabric
   description: Complete reference of the AddEdgeDeviceInSDAFabric API.

--- a/plugins/modules/sda_fabric_edge_device_info.py
+++ b/plugins/modules/sda_fabric_edge_device_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceManagementIpAddress query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetEdgeDeviceFromSDAFabric
   description: Complete reference of the GetEdgeDeviceFromSDAFabric API.

--- a/plugins/modules/sda_fabric_info.py
+++ b/plugins/modules/sda_fabric_info.py
@@ -24,8 +24,8 @@ options:
     - FabricName query parameter. Fabric Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     sda.Sda.get_sda_fabric_info,

--- a/plugins/modules/sda_fabric_site.py
+++ b/plugins/modules/sda_fabric_site.py
@@ -31,8 +31,8 @@ options:
     description: SiteNameHierarchy query parameter. Site Name Hierarchy.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddSiteInSDAFabric
   description: Complete reference of the AddSiteInSDAFabric API.

--- a/plugins/modules/sda_fabric_site_info.py
+++ b/plugins/modules/sda_fabric_site_info.py
@@ -24,8 +24,8 @@ options:
     - SiteNameHierarchy query parameter. Site Name Hierarchy.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetSiteFromSDAFabric
   description: Complete reference of the GetSiteFromSDAFabric API.

--- a/plugins/modules/sda_multicast.py
+++ b/plugins/modules/sda_multicast.py
@@ -56,8 +56,8 @@ options:
     description: Full path of sda Fabric Site.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddMulticastInSDAFabric
   description: Complete reference of the AddMulticastInSDAFabric API.

--- a/plugins/modules/sda_multicast_info.py
+++ b/plugins/modules/sda_multicast_info.py
@@ -24,8 +24,8 @@ options:
     - SiteNameHierarchy query parameter. Fabric site name hierarchy.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetMulticastDetailsFromSDAFabric
   description: Complete reference of the GetMulticastDetailsFromSDAFabric API.

--- a/plugins/modules/sda_port_assignment_for_access_point.py
+++ b/plugins/modules/sda_port_assignment_for_access_point.py
@@ -41,8 +41,8 @@ options:
     type: str
     version_added: 4.0.0
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddPortAssignmentForAccessPointInSDAFabric
   description: Complete reference of the AddPortAssignmentForAccessPointInSDAFabric API.

--- a/plugins/modules/sda_port_assignment_for_access_point_info.py
+++ b/plugins/modules/sda_port_assignment_for_access_point_info.py
@@ -29,8 +29,8 @@ options:
     - InterfaceName query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetPortAssignmentForAccessPointInSDAFabric
   description: Complete reference of the GetPortAssignmentForAccessPointInSDAFabric API.

--- a/plugins/modules/sda_port_assignment_for_user_device.py
+++ b/plugins/modules/sda_port_assignment_for_user_device.py
@@ -54,8 +54,8 @@ options:
     type: str
     version_added: 4.0.0
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddPortAssignmentForUserDeviceInSDAFabric
   description: Complete reference of the AddPortAssignmentForUserDeviceInSDAFabric API.

--- a/plugins/modules/sda_port_assignment_for_user_device_info.py
+++ b/plugins/modules/sda_port_assignment_for_user_device_info.py
@@ -28,8 +28,8 @@ options:
     - InterfaceName query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetPortAssignmentForUserDeviceInSDAFabric
   description: Complete reference of the GetPortAssignmentForUserDeviceInSDAFabric API.

--- a/plugins/modules/sda_provision_device.py
+++ b/plugins/modules/sda_provision_device.py
@@ -26,8 +26,8 @@ options:
     description: SiteNameHierarchy of the provisioned device.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA ProvisionWiredDevice
   description: Complete reference of the ProvisionWiredDevice API.

--- a/plugins/modules/sda_provision_device_info.py
+++ b/plugins/modules/sda_provision_device_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceManagementIpAddress query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetProvisionedWiredDevice
   description: Complete reference of the GetProvisionedWiredDevice API.

--- a/plugins/modules/sda_virtual_network.py
+++ b/plugins/modules/sda_virtual_network.py
@@ -24,8 +24,8 @@ options:
     description: VirtualNetworkName query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddVNInFabric
   description: Complete reference of the AddVNInFabric API.

--- a/plugins/modules/sda_virtual_network_info.py
+++ b/plugins/modules/sda_virtual_network_info.py
@@ -28,8 +28,8 @@ options:
     - SiteNameHierarchy query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetVNFromSDAFabric
   description: Complete reference of the GetVNFromSDAFabric API.

--- a/plugins/modules/sda_virtual_network_ip_pool.py
+++ b/plugins/modules/sda_virtual_network_ip_pool.py
@@ -83,8 +83,8 @@ options:
     type: str
     version_added: 4.0.0
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddIPPoolInSDAVirtualNetwork
   description: Complete reference of the AddIPPoolInSDAVirtualNetwork API.

--- a/plugins/modules/sda_virtual_network_ip_pool_info.py
+++ b/plugins/modules/sda_virtual_network_ip_pool_info.py
@@ -34,8 +34,8 @@ options:
     - IpPoolName query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetIPPoolFromSDAVirtualNetwork
   description: Complete reference of the GetIPPoolFromSDAVirtualNetwork API.

--- a/plugins/modules/sda_virtual_network_v2.py
+++ b/plugins/modules/sda_virtual_network_v2.py
@@ -32,8 +32,8 @@ options:
     description: Virtual Network Name to be assigned at global level.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA AddVirtualNetworkWithScalableGroups
   description: Complete reference of the AddVirtualNetworkWithScalableGroups API.

--- a/plugins/modules/sda_virtual_network_v2_info.py
+++ b/plugins/modules/sda_virtual_network_v2_info.py
@@ -24,8 +24,8 @@ options:
     - VirtualNetworkName query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for SDA GetVirtualNetworkWithScalableGroups
   description: Complete reference of the GetVirtualNetworkWithScalableGroups API.

--- a/plugins/modules/security_advisories_devices_info.py
+++ b/plugins/modules/security_advisories_devices_info.py
@@ -24,8 +24,8 @@ options:
     - AdvisoryId path parameter. Advisory ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Security Advisories GetDevicesPerAdvisory
   description: Complete reference of the GetDevicesPerAdvisory API.

--- a/plugins/modules/security_advisories_ids_per_device_info.py
+++ b/plugins/modules/security_advisories_ids_per_device_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceId path parameter. Device instance UUID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Security Advisories GetAdvisoryIDsPerDevice
   description: Complete reference of the GetAdvisoryIDsPerDevice API.

--- a/plugins/modules/security_advisories_info.py
+++ b/plugins/modules/security_advisories_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Security Advisories GetAdvisoriesList
   description: Complete reference of the GetAdvisoriesList API.

--- a/plugins/modules/security_advisories_per_device_info.py
+++ b/plugins/modules/security_advisories_per_device_info.py
@@ -24,8 +24,8 @@ options:
     - DeviceId path parameter. Device instance UUID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Security Advisories GetAdvisoriesPerDevice
   description: Complete reference of the GetAdvisoriesPerDevice API.

--- a/plugins/modules/security_advisories_summary_info.py
+++ b/plugins/modules/security_advisories_summary_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Security Advisories GetAdvisoriesSummary
   description: Complete reference of the GetAdvisoriesSummary API.

--- a/plugins/modules/sensor.py
+++ b/plugins/modules/sensor.py
@@ -87,8 +87,8 @@ options:
     description: TemplateName query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sensors CreateSensorTestTemplate
   description: Complete reference of the CreateSensorTestTemplate API.

--- a/plugins/modules/sensor_info.py
+++ b/plugins/modules/sensor_info.py
@@ -24,8 +24,8 @@ options:
     - SiteId query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sensors Sensors
   description: Complete reference of the Sensors API.

--- a/plugins/modules/sensor_test_run.py
+++ b/plugins/modules/sensor_test_run.py
@@ -20,8 +20,8 @@ options:
     description: Template Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sensors RunNowSensorTest
   description: Complete reference of the RunNowSensorTest API.

--- a/plugins/modules/sensor_test_template_duplicate.py
+++ b/plugins/modules/sensor_test_template_duplicate.py
@@ -23,8 +23,8 @@ options:
     description: Template Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sensors DuplicateSensorTestTemplate
   description: Complete reference of the DuplicateSensorTestTemplate API.

--- a/plugins/modules/sensor_test_template_edit.py
+++ b/plugins/modules/sensor_test_template_edit.py
@@ -83,8 +83,8 @@ options:
     description: Template Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sensors EditSensorTestTemplate
   description: Complete reference of the EditSensorTestTemplate API.

--- a/plugins/modules/service_provider_create.py
+++ b/plugins/modules/service_provider_create.py
@@ -35,8 +35,8 @@ options:
         type: list
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings CreateSPProfile
   description: Complete reference of the CreateSPProfile API.

--- a/plugins/modules/service_provider_info.py
+++ b/plugins/modules/service_provider_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings GetServiceProviderDetails
   description: Complete reference of the GetServiceProviderDetails API.

--- a/plugins/modules/service_provider_profile_delete.py
+++ b/plugins/modules/service_provider_profile_delete.py
@@ -20,8 +20,8 @@ options:
     description: SpProfileName path parameter. Sp profile name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings DeleteSPProfile
   description: Complete reference of the DeleteSPProfile API.

--- a/plugins/modules/service_provider_update.py
+++ b/plugins/modules/service_provider_update.py
@@ -38,8 +38,8 @@ options:
         type: list
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings UpdateSPProfile
   description: Complete reference of the UpdateSPProfile API.

--- a/plugins/modules/service_provider_v2.py
+++ b/plugins/modules/service_provider_v2.py
@@ -36,8 +36,8 @@ options:
         type: list
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings CreateSPProfileV2
   description: Complete reference of the CreateSPProfileV2 API.

--- a/plugins/modules/service_provider_v2_info.py
+++ b/plugins/modules/service_provider_v2_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings GetServiceProviderDetailsV2
   description: Complete reference of the GetServiceProviderDetailsV2 API.

--- a/plugins/modules/site_assign_credential.py
+++ b/plugins/modules/site_assign_credential.py
@@ -41,8 +41,8 @@ options:
     description: Snmp V3 Id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings AssignDeviceCredentialToSite
   description: Complete reference of the AssignDeviceCredentialToSite API.

--- a/plugins/modules/site_assign_device.py
+++ b/plugins/modules/site_assign_device.py
@@ -28,8 +28,8 @@ options:
     description: SiteId path parameter. Site id to which site the device to assign.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     sites.Sites.assign_device_to_site,

--- a/plugins/modules/site_count_info.py
+++ b/plugins/modules/site_count_info.py
@@ -24,8 +24,8 @@ options:
     - SiteId query parameter. Site id to retrieve site count.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sites GetSiteCount
   description: Complete reference of the GetSiteCount API.

--- a/plugins/modules/site_create.py
+++ b/plugins/modules/site_create.py
@@ -84,8 +84,8 @@ options:
     description: Type of site to create (eg area, building, floor).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sites CreateSite
   description: Complete reference of the CreateSite API.

--- a/plugins/modules/site_delete.py
+++ b/plugins/modules/site_delete.py
@@ -20,8 +20,8 @@ options:
     description: SiteId path parameter. Site id to which site details to be deleted.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sites DeleteSite
   description: Complete reference of the DeleteSite API.

--- a/plugins/modules/site_design_floormap.py
+++ b/plugins/modules/site_design_floormap.py
@@ -24,8 +24,8 @@ options:
     description: Site Design Floormap's payload
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     site_design.SiteDesign.create_floormap,

--- a/plugins/modules/site_design_floormap_info.py
+++ b/plugins/modules/site_design_floormap_info.py
@@ -26,8 +26,8 @@ options:
     - FloorId path parameter. Group Id of the specified floormap.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     site_design.SiteDesign.get_floormap,

--- a/plugins/modules/site_health_info.py
+++ b/plugins/modules/site_health_info.py
@@ -36,8 +36,8 @@ options:
     - Limit query parameter. The max number of sites in the returned data set. Default is 25, and max at 50.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sites GetSiteHealth
   description: Complete reference of the GetSiteHealth API.

--- a/plugins/modules/site_info.py
+++ b/plugins/modules/site_info.py
@@ -40,8 +40,8 @@ options:
     - Limit query parameter. Number of sites to be retrieved. The default value is 500.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sites GetSite
   description: Complete reference of the GetSite API.

--- a/plugins/modules/site_intent.py
+++ b/plugins/modules/site_intent.py
@@ -120,7 +120,7 @@ options:
 
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     sites.Sites.create_site,

--- a/plugins/modules/site_membership_info.py
+++ b/plugins/modules/site_membership_info.py
@@ -40,8 +40,8 @@ options:
     - SerialNumber query parameter. Device serial number.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sites GetMembership
   description: Complete reference of the GetMembership API.

--- a/plugins/modules/site_update.py
+++ b/plugins/modules/site_update.py
@@ -78,8 +78,8 @@ options:
     description: Type.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Sites UpdateSite
   description: Complete reference of the UpdateSite API.

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -120,7 +120,7 @@ options:
 
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     sites.Sites.create_site,

--- a/plugins/modules/snmp_properties.py
+++ b/plugins/modules/snmp_properties.py
@@ -37,8 +37,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateUpdateSNMPProperties
   description: Complete reference of the CreateUpdateSNMPProperties API.

--- a/plugins/modules/snmp_properties_info.py
+++ b/plugins/modules/snmp_properties_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery GetSNMPProperties
   description: Complete reference of the GetSNMPProperties API.

--- a/plugins/modules/snmpv2_read_community_credential.py
+++ b/plugins/modules/snmpv2_read_community_credential.py
@@ -33,8 +33,8 @@ options:
     description: SNMP read community. NO!$DATA!$ for no value change.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateSNMPReadCommunity
   description: Complete reference of the CreateSNMPReadCommunity API.

--- a/plugins/modules/snmpv2_write_community_credential.py
+++ b/plugins/modules/snmpv2_write_community_credential.py
@@ -33,8 +33,8 @@ options:
     description: SNMP write community. NO!$DATA!$ for no value change.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateSNMPWriteCommunity
   description: Complete reference of the CreateSNMPWriteCommunity API.

--- a/plugins/modules/snmpv3_credential.py
+++ b/plugins/modules/snmpv3_credential.py
@@ -54,8 +54,8 @@ options:
     description: Snmpv3 Credential's username.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Discovery CreateSNMPv3Credentials
   description: Complete reference of the CreateSNMPv3Credentials API.

--- a/plugins/modules/sp_profile_delete_v2.py
+++ b/plugins/modules/sp_profile_delete_v2.py
@@ -20,8 +20,8 @@ options:
     description: SpProfileName path parameter. Sp profile name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Network Settings DeleteSPProfileV2
   description: Complete reference of the DeleteSPProfileV2 API.

--- a/plugins/modules/swim_image_details_info.py
+++ b/plugins/modules/swim_image_details_info.py
@@ -92,8 +92,8 @@ options:
     - Offset query parameter.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) GetSoftwareImageDetails
   description: Complete reference of the GetSoftwareImageDetails API.

--- a/plugins/modules/swim_import_local.py
+++ b/plugins/modules/swim_import_local.py
@@ -35,8 +35,8 @@ options:
     description: ThirdPartyVendor query parameter. Third Party Vendor.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) ImportLocalSoftwareImage
   description: Complete reference of the ImportLocalSoftwareImage API.

--- a/plugins/modules/swim_import_via_url.py
+++ b/plugins/modules/swim_import_via_url.py
@@ -49,8 +49,8 @@ options:
     description: ScheduleOrigin query parameter. Originator of this call (Optional).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) ImportSoftwareImageViaURL
   description: Complete reference of the ImportSoftwareImageViaURL API.

--- a/plugins/modules/swim_intent.py
+++ b/plugins/modules/swim_intent.py
@@ -309,7 +309,7 @@ options:
             type: bool
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     software_image_management_swim.SoftwareImageManagementSwim.import_software_image_via_url,

--- a/plugins/modules/swim_trigger_activation.py
+++ b/plugins/modules/swim_trigger_activation.py
@@ -49,8 +49,8 @@ options:
       before schedule (Optional).
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) TriggerSoftwareImageActivation
   description: Complete reference of the TriggerSoftwareImageActivation API.

--- a/plugins/modules/swim_trigger_distribution.py
+++ b/plugins/modules/swim_trigger_distribution.py
@@ -30,8 +30,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Software Image Management (SWIM) TriggerSoftwareImageDistribution
   description: Complete reference of the TriggerSoftwareImageDistribution API.

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -296,7 +296,7 @@ options:
             type: bool
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     software_image_management_swim.SoftwareImageManagementSwim.import_software_image_via_url,

--- a/plugins/modules/syslog_config_create.py
+++ b/plugins/modules/syslog_config_create.py
@@ -35,8 +35,8 @@ options:
     description: Protocol.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management CreateSyslogDestination
   description: Complete reference of the CreateSyslogDestination API.

--- a/plugins/modules/syslog_config_update.py
+++ b/plugins/modules/syslog_config_update.py
@@ -35,8 +35,8 @@ options:
     description: Protocol.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Event Management UpdateSyslogDestination
   description: Complete reference of the UpdateSyslogDestination API.

--- a/plugins/modules/system_health_count_info.py
+++ b/plugins/modules/system_health_count_info.py
@@ -32,8 +32,8 @@ options:
       here /dna/platform/app/consumer-portal/developer-toolkit/events.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Health and Performance SystemHealthCountAPI
   description: Complete reference of the SystemHealthCountAPI API.

--- a/plugins/modules/system_health_info.py
+++ b/plugins/modules/system_health_info.py
@@ -44,8 +44,8 @@ options:
     - Offset query parameter.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Health and Performance SystemHealthAPI
   description: Complete reference of the SystemHealthAPI API.

--- a/plugins/modules/system_performance_historical_info.py
+++ b/plugins/modules/system_performance_historical_info.py
@@ -36,8 +36,8 @@ options:
       be fetched.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Health and Performance SystemPerformanceHistoricalAPI
   description: Complete reference of the SystemPerformanceHistoricalAPI API.

--- a/plugins/modules/system_performance_info.py
+++ b/plugins/modules/system_performance_info.py
@@ -40,8 +40,8 @@ options:
       be fetched.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Health and Performance SystemPerformanceAPI
   description: Complete reference of the SystemPerformanceAPI API.

--- a/plugins/modules/tag.py
+++ b/plugins/modules/tag.py
@@ -63,8 +63,8 @@ options:
     description: SystemTag flag.
     type: bool
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag CreateTag
   description: Complete reference of the CreateTag API.

--- a/plugins/modules/tag_count_info.py
+++ b/plugins/modules/tag_count_info.py
@@ -44,8 +44,8 @@ options:
     - SystemTag query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag GetTagCount
   description: Complete reference of the GetTagCount API.

--- a/plugins/modules/tag_info.py
+++ b/plugins/modules/tag_info.py
@@ -72,8 +72,8 @@ options:
     - Id path parameter. Tag ID.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag GetTag
   description: Complete reference of the GetTag API.

--- a/plugins/modules/tag_member.py
+++ b/plugins/modules/tag_member.py
@@ -30,8 +30,8 @@ options:
     description: Map of member type and member ids.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag AddMembersToTheTag
   description: Complete reference of the AddMembersToTheTag API.

--- a/plugins/modules/tag_member_count_info.py
+++ b/plugins/modules/tag_member_count_info.py
@@ -36,8 +36,8 @@ options:
     - Level query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag GetTagMemberCount
   description: Complete reference of the GetTagMemberCount API.

--- a/plugins/modules/tag_member_info.py
+++ b/plugins/modules/tag_member_info.py
@@ -50,8 +50,8 @@ options:
     - Level query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag GetTagMembersById
   description: Complete reference of the GetTagMembersById API.

--- a/plugins/modules/tag_member_type_info.py
+++ b/plugins/modules/tag_member_type_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag GetTagResourceTypes
   description: Complete reference of the GetTagResourceTypes API.

--- a/plugins/modules/tag_membership.py
+++ b/plugins/modules/tag_membership.py
@@ -32,8 +32,8 @@ options:
     description: Tag Membership's memberType.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Tag UpdatesTagMembership
   description: Complete reference of the UpdatesTagMembership API.

--- a/plugins/modules/task_count_info.py
+++ b/plugins/modules/task_count_info.py
@@ -60,8 +60,8 @@ options:
     - ParentId query parameter. Fetch tasks that have this parent Id.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Task GetTaskCount
   description: Complete reference of the GetTaskCount API.

--- a/plugins/modules/task_info.py
+++ b/plugins/modules/task_info.py
@@ -82,8 +82,8 @@ options:
     - TaskId path parameter. UUID of the Task.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Task GetTaskById
   description: Complete reference of the GetTaskById API.

--- a/plugins/modules/task_operation_info.py
+++ b/plugins/modules/task_operation_info.py
@@ -34,8 +34,8 @@ options:
       value is 1.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Task GetTaskByOperationId
   description: Complete reference of the GetTaskByOperationId API.

--- a/plugins/modules/task_tree_info.py
+++ b/plugins/modules/task_tree_info.py
@@ -24,8 +24,8 @@ options:
     - TaskId path parameter. UUID of the Task.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Task GetTaskTree
   description: Complete reference of the GetTaskTree API.

--- a/plugins/modules/template_intent.py
+++ b/plugins/modules/template_intent.py
@@ -1104,7 +1104,7 @@ options:
 
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     configuration_templates.ConfigurationTemplates.create_template,

--- a/plugins/modules/template_preview.py
+++ b/plugins/modules/template_preview.py
@@ -29,8 +29,8 @@ options:
     description: UUID of template to get template preview.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates PreviewTemplate
   description: Complete reference of the PreviewTemplate API.

--- a/plugins/modules/template_workflow_manager.py
+++ b/plugins/modules/template_workflow_manager.py
@@ -1104,7 +1104,7 @@ options:
 
 requirements:
 - dnacentersdk == 2.4.5
-- python >= 3.5
+- python >= 3.9
 notes:
   - SDK Method used are
     configuration_templates.ConfigurationTemplates.create_template,

--- a/plugins/modules/templates_details_info.py
+++ b/plugins/modules/templates_details_info.py
@@ -89,8 +89,8 @@ options:
     - Limit query parameter. Limits number of results.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Configuration Templates GetTemplatesDetails
   description: Complete reference of the GetTemplatesDetails API.

--- a/plugins/modules/threat_detail.py
+++ b/plugins/modules/threat_detail.py
@@ -44,8 +44,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     devices.Devices.threat_details,

--- a/plugins/modules/threat_detail_count.py
+++ b/plugins/modules/threat_detail_count.py
@@ -44,8 +44,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     devices.Devices.threat_detail_count,

--- a/plugins/modules/threat_summary.py
+++ b/plugins/modules/threat_summary.py
@@ -35,8 +35,8 @@ options:
     elements: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 notes:
   - SDK Method used are
     devices.Devices.threat_summary,

--- a/plugins/modules/topology_layer_2_info.py
+++ b/plugins/modules/topology_layer_2_info.py
@@ -24,8 +24,8 @@ options:
     - VlanID path parameter. Vlan Name for e.g Vlan1, Vlan23 etc.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Topology GetTopologyDetails
   description: Complete reference of the GetTopologyDetails API.

--- a/plugins/modules/topology_layer_3_info.py
+++ b/plugins/modules/topology_layer_3_info.py
@@ -24,8 +24,8 @@ options:
     - TopologyType path parameter. Type of topology(OSPF,ISIS,etc).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Topology GetL3TopologyDetails
   description: Complete reference of the GetL3TopologyDetails API.

--- a/plugins/modules/topology_network_health_info.py
+++ b/plugins/modules/topology_network_health_info.py
@@ -26,8 +26,8 @@ options:
     - Timestamp query parameter. Epoch time(in milliseconds) when the Network health data is required.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Topology GetOverallNetworkHealth
   description: Complete reference of the GetOverallNetworkHealth API.

--- a/plugins/modules/topology_physical_info.py
+++ b/plugins/modules/topology_physical_info.py
@@ -24,8 +24,8 @@ options:
     - NodeType query parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Topology GetPhysicalTopology
   description: Complete reference of the GetPhysicalTopology API.

--- a/plugins/modules/topology_site_info.py
+++ b/plugins/modules/topology_site_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Topology GetSiteTopology
   description: Complete reference of the GetSiteTopology API.

--- a/plugins/modules/topology_vlan_details_info.py
+++ b/plugins/modules/topology_vlan_details_info.py
@@ -20,8 +20,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Topology GetVLANDetails
   description: Complete reference of the GetVLANDetails API.

--- a/plugins/modules/transit_peer_network.py
+++ b/plugins/modules/transit_peer_network.py
@@ -49,8 +49,8 @@ options:
     description: Transit Peer Network Type.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for  AddTransitPeerNetwork
   description: Complete reference of the AddTransitPeerNetwork API.

--- a/plugins/modules/transit_peer_network_info.py
+++ b/plugins/modules/transit_peer_network_info.py
@@ -24,8 +24,8 @@ options:
     - TransitPeerNetworkName query parameter. Transit or Peer Network Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for  GetTransitPeerNetworkInfo
   description: Complete reference of the GetTransitPeerNetworkInfo API.

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -40,8 +40,8 @@ options:
     description: Username.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for User and Roles AddUserAPI
   description: Complete reference of the AddUserAPI API.

--- a/plugins/modules/user_enrichment_details_info.py
+++ b/plugins/modules/user_enrichment_details_info.py
@@ -22,8 +22,8 @@ options:
     description: Additional headers.
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Users GetUserEnrichmentDetails
   description: Complete reference of the GetUserEnrichmentDetails API.

--- a/plugins/modules/user_info.py
+++ b/plugins/modules/user_info.py
@@ -24,8 +24,8 @@ options:
     - InvokeSource query parameter. The source that invokes this API.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for User and Roles GetUsersAPI
   description: Complete reference of the GetUsersAPI API.

--- a/plugins/modules/users_external_servers_info.py
+++ b/plugins/modules/users_external_servers_info.py
@@ -24,8 +24,8 @@ options:
     - InvokeSource query parameter. The source that invokes this API.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for User and Roles GetExternalAuthenticationServersAPI
   description: Complete reference of the GetExternalAuthenticationServersAPI API.

--- a/plugins/modules/wireless_accespoint_configuration.py
+++ b/plugins/modules/wireless_accespoint_configuration.py
@@ -238,8 +238,8 @@ options:
         type: str
     type: dict
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless ConfigureAccessPoints
   description: Complete reference of the ConfigureAccessPoints API.

--- a/plugins/modules/wireless_accesspoint_configuration_summary_info.py
+++ b/plugins/modules/wireless_accesspoint_configuration_summary_info.py
@@ -24,8 +24,8 @@ options:
     - Key query parameter. The ethernet MAC address of Access point.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless GetAccessPointConfiguration
   description: Complete reference of the GetAccessPointConfiguration API.

--- a/plugins/modules/wireless_dynamic_interface.py
+++ b/plugins/modules/wireless_dynamic_interface.py
@@ -27,8 +27,8 @@ options:
     description: Vlan Id.
     type: int
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless CreateUpdateDynamicInterface
   description: Complete reference of the CreateUpdateDynamicInterface API.

--- a/plugins/modules/wireless_dynamic_interface_info.py
+++ b/plugins/modules/wireless_dynamic_interface_info.py
@@ -26,8 +26,8 @@ options:
       will be retrieved.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless GetDynamicInterface
   description: Complete reference of the GetDynamicInterface API.

--- a/plugins/modules/wireless_enterprise_ssid.py
+++ b/plugins/modules/wireless_enterprise_ssid.py
@@ -81,8 +81,8 @@ options:
     description: Traffic Type Enum (voicedata or data ).
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless CreateEnterpriseSSID
   description: Complete reference of the CreateEnterpriseSSID API.

--- a/plugins/modules/wireless_enterprise_ssid_info.py
+++ b/plugins/modules/wireless_enterprise_ssid_info.py
@@ -26,8 +26,8 @@ options:
       enterprise SSIDs will be retrieved.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless GetEnterpriseSSID
   description: Complete reference of the GetEnterpriseSSID API.

--- a/plugins/modules/wireless_profile.py
+++ b/plugins/modules/wireless_profile.py
@@ -68,8 +68,8 @@ options:
     description: WirelessProfileName path parameter. Wireless Profile Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless CreateWirelessProfile
   description: Complete reference of the CreateWirelessProfile API.

--- a/plugins/modules/wireless_profile_info.py
+++ b/plugins/modules/wireless_profile_info.py
@@ -24,8 +24,8 @@ options:
     - ProfileName query parameter. Wireless Network Profile Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless GetWirelessProfile
   description: Complete reference of the GetWirelessProfile API.

--- a/plugins/modules/wireless_provision_access_point.py
+++ b/plugins/modules/wireless_provision_access_point.py
@@ -47,8 +47,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless APProvision
   description: Complete reference of the APProvision API.

--- a/plugins/modules/wireless_provision_device_create.py
+++ b/plugins/modules/wireless_provision_device_create.py
@@ -55,8 +55,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless Provision
   description: Complete reference of the Provision API.

--- a/plugins/modules/wireless_provision_device_update.py
+++ b/plugins/modules/wireless_provision_device_update.py
@@ -55,8 +55,8 @@ options:
         type: list
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless ProvisionUpdate
   description: Complete reference of the ProvisionUpdate API.

--- a/plugins/modules/wireless_provision_ssid_create_provision.py
+++ b/plugins/modules/wireless_provision_ssid_create_provision.py
@@ -78,8 +78,8 @@ options:
     description: SSID Type.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless CreateAndProvisionSSID
   description: Complete reference of the CreateAndProvisionSSID API.

--- a/plugins/modules/wireless_provision_ssid_delete_reprovision.py
+++ b/plugins/modules/wireless_provision_ssid_delete_reprovision.py
@@ -26,8 +26,8 @@ options:
     description: SsidName path parameter.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless DeleteSSIDAndProvisionItToDevices
   description: Complete reference of the DeleteSSIDAndProvisionItToDevices API.

--- a/plugins/modules/wireless_psk_override.py
+++ b/plugins/modules/wireless_psk_override.py
@@ -34,8 +34,8 @@ options:
         type: str
     type: list
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless PSKOverride
   description: Complete reference of the PSKOverride API.

--- a/plugins/modules/wireless_rf_profile.py
+++ b/plugins/modules/wireless_rf_profile.py
@@ -130,8 +130,8 @@ options:
       *non-custom RF profile cannot be deleted.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless CreateOrUpdateRFProfile
   description: Complete reference of the CreateOrUpdateRFProfile API.

--- a/plugins/modules/wireless_rf_profile_info.py
+++ b/plugins/modules/wireless_rf_profile_info.py
@@ -24,8 +24,8 @@ options:
     - Rf-profile-name query parameter. RF Profile Name.
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless RetrieveRFProfiles
   description: Complete reference of the RetrieveRFProfiles API.

--- a/plugins/modules/wireless_sensor_test_results_info.py
+++ b/plugins/modules/wireless_sensor_test_results_info.py
@@ -36,8 +36,8 @@ options:
     - TestFailureBy query parameter. Obtain failure statistics group by "area", "building", or "floor".
     type: str
 requirements:
-- dnacentersdk >= 2.5.5
-- python >= 3.5
+- dnacentersdk >= 2.6.0
+- python >= 3.9
 seealso:
 - name: Cisco DNA Center documentation for Wireless SensorTestResults
   description: Complete reference of the SensorTestResults API.


### PR DESCRIPTION
### TL;DR

+ **A new README template** has been finalized for certified collections. This template will be available soon for documentation, with enforcement at the end of Q2 2024 for new collection versions. 

+ AAP 2.3 and **Ansible Core 2.14 are EoL** on May 31, 2024. Make sure all metadata and documentation is updated accordingly. If you have not updated your certified collection since July 1, 2023 on Automation Hub, your collection is slated for deprecation. A new release must be approved by May 31, 2024 to avoid deprecation and eventual removal. 

+ **Ansible Lint 6.22.2** upgrade in the Automation Hub import pipeline is now scheduled for Q2 2024. Make sure you’re using this version in local and CI tests.
    
From the Google Groups "ansible-partner-announce-list" group.